### PR TITLE
Update rivian-python-client to v2.1.0-beta.4

### DIFF
--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bretterer/home-assistant-rivian/issues",
   "loggers": ["custom_components.rivian", "rivian"],
-  "requirements": ["rivian-python-client[ble]==1.4.1"],
+  "requirements": ["rivian-python-client[ble] @ git+https://github.com/jrgutier/rivian-python-client.git@v2.1.0-beta.4"],
   "version": "0.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-dateutil
 PyTurboJPEG
 
 # Integration
-rivian-python-client[ble]==1.4.1
+rivian-python-client[ble] @ git+https://github.com/jrgutier/rivian-python-client.git@v2.1.0-beta.4
 
 # Development
 colorlog


### PR DESCRIPTION
Update the rivian-python-client dependency from 1.4.1 to v2.1.0-beta.4 using git-based installation from jrgutier/rivian-python-client repository.