### PR TITLE
Push connectivity state transitions to entities

### DIFF
--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -1401,6 +1401,18 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
                 if self._subscription_start_time
                 else 0,
             )
+            # Push the transition to the entities. This callback writes
+            # `_is_online`, which is half of connectivity_state() -- and
+            # connectivity_state() is now gate 1 of every control's availability
+            # AND the cloud_connected sensor's state. Nothing else refreshes it:
+            # `_async_update_data` returns `self.data` unchanged and the
+            # coordinator is constructed with `always_update=False`, so the
+            # scheduled refresh notifies nobody, and the only other notifier is a
+            # vehicleState/Parallax frame -- which a vehicle that just went
+            # offline has stopped sending. Without this, a vehicle going OFFLINE
+            # leaves every control showing as available and cloud_connected
+            # showing `on` until the vehicle comes back and speaks again.
+            self.async_update_listeners()
         else:
             _LOGGER.debug(
                 "Vehicle %s cloud connection: online=%s, lastSync=%s",

--- a/scripts/gates/_lib.sh
+++ b/scripts/gates/_lib.sh
@@ -255,12 +255,19 @@ pytest_green() {
   # Read from the ENVIRONMENT, not a positional: callers pass pytest args through
   # "$@", so a fourth positional would collide with them.
   #
-  # Default 0 -- the exemption must be asked for. `|| true` on both greps: each
-  # exits 1 on no match, and pipefail would make that fatal.
+  # Default 0 -- the exemption must be asked for. `|| true` on the grep: it exits
+  # 1 on no match, and pipefail would make that fatal.
+  #
+  # SUMMED, not `head -1`. pytest's summary carries both counts and their order is
+  # not fixed: "1690 passed, 5 deselected, 3 skipped" and "3 skipped, 5 deselected"
+  # are both possible, so reading the first match alone judged whichever number
+  # happened to come first and never looked at the other. With the BLE exemption
+  # set (PYTEST_GREEN_ALLOWED_SKIPS=N) that let N deselections satisfy a budget
+  # meant for skips while real skips went unexamined. awk sums and prints 0 on no
+  # input, so the no-match case needs no separate guard.
   allowed="${PYTEST_GREEN_ALLOWED_SKIPS:-0}"
   skips=$( { echo "$out" | grep -oE '[0-9]+ (skipped|deselected)' || true; } \
-           | { grep -oE '^[0-9]+' || true; } | head -1)
-  skips="${skips:-0}"
+           | awk '{ s += $1 } END { print s + 0 }')
   if [ "$skips" -le "$allowed" ]; then
     if [ "$allowed" -eq 0 ]; then ok "$label: nothing skipped or deselected"
     else ok "$label: skips $skips <= allowed $allowed"; fi

--- a/scripts/gates/s01.sh
+++ b/scripts/gates/s01.sh
@@ -26,11 +26,23 @@ if [ -x "$HA/scripts/check_coverage.py" ] || [ -f "$HA/scripts/check_coverage.py
   # code. (Order-dependence is the exact defect s01b's own story was written to
   # fix, in the test suite.) f5.sh already regenerates for this reason; this
   # follows that precedent.
-  if (cd "$HA" && .venv/bin/pytest -q -p no:cacheprovider >/dev/null 2>&1 \
-      && .venv/bin/python scripts/check_coverage.py >/dev/null 2>&1); then
+  #
+  # The regeneration is judged SEPARATELY from the floors. Chained into one `&&`
+  # they were indistinguishable: a suite that failed, errored during collection or
+  # could not start reported "check_coverage.py does not pass against the current
+  # coverage.json" -- a false accusation about the floors, which is the exact
+  # defect class test_count and pytest_green were written to remove from the other
+  # gates in this same change. pytest.ini sets no --cov-fail-under, so a non-zero
+  # exit here is a red suite and nothing else.
+  COV_PY="$(resolve_pytest "$HA")"
+  if [ ! -x "$COV_PY" ]; then
+    bad "pytest not found — coverage.json cannot be regenerated (ENVIRONMENT problem, NOT an unmet floor)"
+  elif ! (cd "$HA" && "$COV_PY" -q -p no:cacheprovider >/dev/null 2>&1); then
+    bad "the suite is red — coverage.json was not regenerated, so the floors are UNJUDGED (not unmet)"
+  elif (cd "$HA" && "$(resolve_python "$HA")" scripts/check_coverage.py >/dev/null 2>&1); then
     ok "both floors currently met"
   else
-    bad "check_coverage.py does not pass against the current coverage.json"
+    bad "check_coverage.py does not pass against the freshly regenerated coverage.json"
   fi
 else
   bad "no scripts/check_coverage.py and no --cov-fail-under — nothing ratchets"

--- a/scripts/ws_contention_probe.py
+++ b/scripts/ws_contention_probe.py
@@ -109,7 +109,7 @@ def rejection_count() -> int:
         return 0
 
 
-def liveness(
+async def liveness(
     a0: float, w: float, t_close: float, baseline_rejects: int
 ) -> tuple[str, dict]:
     """One of three verdicts, after every arm, before the next begins.
@@ -118,18 +118,27 @@ def liveness(
     rejection line, which means the monitor stopped; the second is silence,
     which cannot distinguish a stopped monitor from a vehicle gone quiet. The
     step records that rather than guessing.
+
+    ASYNC, and every blocking part offloaded, because this waits up to W = 900 s
+    between arms while the aiohttp session and the client's websocket monitor
+    from arms 3a/3b are still open. `time.sleep` plus a synchronous `ssh`
+    subprocess held the event loop for that whole window, so the monitor could
+    not read or answer a keepalive -- and arm 3c, whose entire question is
+    whether the init is acked in the SAME session 3a/3b used, would then be
+    measuring a session this probe itself starved. An instrument artifact
+    reported as a refusal is exactly the failure this file exists to stop.
     """
     deadline = time.time() + w
     first_row = None
     while time.time() < deadline:
-        if rejection_count() > baseline_rejects:
+        if await asyncio.to_thread(rejection_count) > baseline_rejects:
             return "LIVENESS FAILED", {"reason": REJECT_TEXT, "a0": a0, "w": w}
-        ts = newest_row_ts()
+        ts = await asyncio.to_thread(newest_row_ts)
         if ts and ts > t_close:
             first_row = ts
             break
-        time.sleep(10)
-    rejects = rejection_count()
+        await asyncio.sleep(10)
+    rejects = await asyncio.to_thread(rejection_count)
     if rejects > baseline_rejects:
         return "LIVENESS FAILED", {"rejects": rejects, "a0": a0, "w": w}
     if first_row is None:
@@ -405,7 +414,7 @@ async def main() -> int:
             r = await fn(client, vid)
             results.append(r)
             print(json.dumps(r, indent=2, default=str))
-            verdict, detail = liveness(a0, w, r["t_close"], baseline)
+            verdict, detail = await liveness(a0, w, r["t_close"], baseline)
             r["liveness"] = verdict
             print(f"  -> {verdict}  {detail}\n")
             if verdict != "LIVENESS OK":
@@ -426,7 +435,7 @@ async def main() -> int:
         r = await arm_3c(client)
         results.append(r)
         print(json.dumps(r, indent=2, default=str))
-        verdict, detail = liveness(a0, w, r["t_close"], baseline)
+        verdict, detail = await liveness(a0, w, r["t_close"], baseline)
         r["liveness"] = verdict
         print(f"  -> {verdict}  {detail}\n")
 

--- a/tests/test_coordinator_callbacks.py
+++ b/tests/test_coordinator_callbacks.py
@@ -101,6 +101,38 @@ class TestCloudConnection:
         coordinator._is_online = False
         assert coordinator.connectivity_state() is ConnectivityState.OFFLINE
 
+    def test_a_transition_pushes_the_new_state_to_the_entities(
+        self, coordinator
+    ) -> None:
+        """A cloud-connection transition must refresh the entities that read it.
+
+        `_is_online` is half of `connectivity_state()`, which is gate 1 of every
+        control's availability and the `cloud_connected` sensor's state. Nothing
+        else notifies on it: `_async_update_data` returns `self.data` unchanged
+        and the coordinator is built with `always_update=False`, so the scheduled
+        refresh notifies nobody, and the only other notifier is a
+        vehicleState/Parallax frame -- which a vehicle that has just gone offline
+        has stopped sending. Without the push, going OFFLINE leaves every control
+        showing available and `cloud_connected` showing `on` until the vehicle
+        comes back and speaks again.
+        """
+        coordinator.async_update_listeners = MagicMock()
+        coordinator._is_online = True
+
+        coordinator._process_cloud_connection_data(_cloud(isOnline=False))
+
+        assert coordinator.async_update_listeners.call_count == 1
+
+    def test_a_repeated_state_does_not_push(self, coordinator) -> None:
+        """Only transitions push. The cloud repeats `isOnline` on every frame, and
+        waking every entity on an unchanged value is churn, not information."""
+        coordinator.async_update_listeners = MagicMock()
+        coordinator._is_online = False
+
+        coordinator._process_cloud_connection_data(_cloud(isOnline=False))
+
+        assert coordinator.async_update_listeners.call_count == 0
+
     @pytest.mark.parametrize(
         "message", [{}, {"payload": {}}, {"payload": {"data": None}}]
     )


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where vehicle controls and the cloud connection sensor would not update their availability state when the vehicle went offline. The fix ensures that connectivity state transitions are immediately pushed to all listening entities, rather than waiting for the next scheduled update.

## Key Changes

### Core Fix: Coordinator Connectivity State Push
- **`custom_components/rivian/coordinator.py`**: Added `self.async_update_listeners()` call in `_process_cloud_connection_data()` when `_is_online` transitions between states
  - This ensures entities are notified immediately when connectivity changes
  - Prevents stale UI state where controls show "available" and `cloud_connected` shows "on" after vehicle goes offline
  - Only pushes on actual state transitions, not on repeated values (reduces unnecessary entity refreshes)

### Test Coverage
- **`tests/test_coordinator_callbacks.py`**: Added two new test cases
  - `test_a_transition_pushes_the_new_state_to_the_entities`: Verifies that state transitions trigger entity updates
  - `test_a_repeated_state_does_not_push`: Verifies that repeated unchanged states do not trigger unnecessary updates

### Event Loop Blocking Fix: Liveness Probe
- **`scripts/ws_contention_probe.py`**: Converted `liveness()` function to async and offloaded all blocking operations
  - Changed `time.sleep(10)` to `await asyncio.sleep(10)`
  - Wrapped blocking calls (`rejection_count()`, `newest_row_ts()`) with `asyncio.to_thread()`
  - Updated callers in `main()` to await the function
  - Prevents the event loop from being blocked during long wait periods (up to 900s), which was causing the WebSocket monitor to starve and report false failures

### Test Gate Improvements
- **`scripts/gates/s01.sh`**: Improved coverage floor validation logic
  - Separated pytest execution from coverage check validation
  - Provides clearer error messages distinguishing between suite failures and unmet coverage floors
  - Uses `resolve_pytest` and `resolve_python` helpers for consistent tool resolution

- **`scripts/gates/_lib.sh`**: Fixed `pytest_green()` skip/deselection counting
  - Changed from reading first match to summing all skip/deselection counts
  - Prevents false positives where deselections could satisfy a skip budget
  - Uses `awk` to sum counts, handles edge cases properly

## Implementation Details

The connectivity state push is necessary because:
- `connectivity_state()` is the primary gate for control availability and the `cloud_connected` sensor state
- `_async_update_data()` returns unchanged data, so scheduled refreshes don't notify listeners
- The only other update source is vehicle state frames, which stop arriving when the vehicle goes offline
- Without the push, offline transitions would not be reflected in the UI until the vehicle reconnects

The liveness probe async conversion prevents a critical issue where the probe itself was starving the WebSocket monitor by holding the event loop during long waits, causing false failure reports.

https://claude.ai/code/session_01AnbxfEFoz6ao3caV42uBXw