### PR TITLE
Reproducible dev venv, and a SessionStart hook that builds it

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SessionStart hook: build .venv/ before the session begins, so a web session can
+# run pytest, ruff and the gates in scripts/gates/ on its first turn.
+#
+# Without this a remote session has no usable environment at all, and the failure
+# is actively misleading: the distro ships CPython 3.10-3.13, homeassistant
+# (pinned in requirements_test.txt) requires >=3.14.2, and pip responds to a
+# too-old interpreter by filtering the index and offering a two-year-old release.
+# That looks exactly like a stale package index, so the time goes into the wrong
+# problem. scripts/setup_dev_env.sh carries the actual fix and the full
+# explanation.
+#
+# Synchronous on purpose: an async hook lets the first turn start before the venv
+# exists, and a session that reaches for pytest a second too early gets a
+# ModuleNotFoundError that reads as a code failure.
+set -euo pipefail
+
+# Local checkouts are left alone -- a developer's environment is theirs, and this
+# would rebuild it out from under them. Run scripts/setup_dev_env.sh by hand for
+# the same result.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+exec bash "${CLAUDE_PROJECT_DIR:-$(dirname "$0")/../..}/scripts/setup_dev_env.sh"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,29 @@ This is an unofficial Home Assistant custom integration for Rivian vehicles. It 
 
 ## Development Commands
 
+### Environment setup
+
+```bash
+bash scripts/setup_dev_env.sh   # builds .venv/, then: .venv/bin/pytest -q
+```
+
+**`python3 -m venv` does not work here, and the way it fails is misleading.**
+`requirements_test.txt` pins `pytest-homeassistant-custom-component`, which pins
+`homeassistant==2026.8.2`, which requires **Python >= 3.14.2**. Distros ship 3.10-3.13,
+and pip's response to a too-old interpreter is not an error about the interpreter --
+it filters the index by `Requires-Python` and reports the newest version that *does*
+match (`2024.3.3` on 3.11), which reads as a stale or broken package index. It is
+not: PyPI is fine, the interpreter is too old. The script fetches 3.14 with `uv`,
+mirroring `.github/workflows/test.yaml` so local and CI cannot drift.
+
+`uv` being merely present is not enough either: a `uv` predating the 3.14 release
+installs `3.14.0rc2`, which is *below* 3.14.2 under PEP 440, and the only symptom is
+an unresolvable `homeassistant` pin. The script checks the interpreter uv can
+actually produce and upgrades uv when it cannot.
+
+Web sessions run this automatically -- `.claude/hooks/session-start.sh`, synchronous
+so the venv exists before the first turn. Local checkouts are left alone.
+
 ### Linting and Formatting
 
 The project uses Ruff for both linting and formatting:

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Build the development virtualenv at .venv/ -- what pytest, ruff and every gate
+# in scripts/gates/ expect to find (resolve_pytest in gates/_lib.sh looks there
+# first).
+#
+# Mirrors .github/workflows/test.yaml step for step -- uv, an explicitly pinned
+# 3.14, then requirements_test.txt and nothing else -- because the whole point of
+# a local venv is to reproduce CI. Two setup recipes that drift are how "green
+# locally, red in CI" starts, which is the same reason the workflow keeps its pins
+# in requirements_test.txt rather than in the workflow body.
+#
+# Idempotent: a .venv already on a qualifying interpreter is kept and its
+# requirements re-synced, so re-running is cheap and safe.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Pinned, not floored, for the reason the workflow gives: HA's own floor moves
+# with its releases, and an environment picking a different minor than CI is how
+# a suite goes green in one place and red in the other.
+PYTHON_VERSION=3.14
+
+# The floor that actually bites, and the reason `python3 -m venv` does not work
+# here. requirements_test.txt pins pytest-homeassistant-custom-component, which
+# pins homeassistant==2026.8.2, which declares requires-python >=3.14.2. On any
+# older interpreter pip does not error usefully -- it filters the index by
+# Requires-Python and reports the newest version that DOES match (2024.3.3 on
+# 3.11), which reads as a stale or broken index rather than an interpreter that is
+# too old. Bump this with the pins in requirements_test.txt.
+MIN_PYTHON='>=3.14.2'
+
+log() { printf '  %s\n' "$*"; }
+
+# --- uv ------------------------------------------------------------------------
+# uv is the installer CI uses, and it is also the only one here that can PROVIDE
+# a 3.14: the distro ships 3.10-3.13, so an interpreter has to be fetched.
+if ! command -v uv >/dev/null 2>&1; then
+  log "uv not found — installing it from PyPI"
+  python3 -m pip install --quiet --user --upgrade uv
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# A uv that is merely PRESENT is not enough, and this is the trap worth naming: a
+# uv older than the 3.14 release knows only the prereleases, so `uv python install
+# 3.14` installs 3.14.0rc2 -- which is BELOW 3.14.2 under PEP 440 and so fails
+# HA's floor. The symptom is an unresolvable homeassistant pin, not a word about
+# the interpreter. So the check is on the interpreter uv can actually produce, and
+# uv is upgraded only when it cannot produce a qualifying one.
+ensure_python() {
+  uv python install "$PYTHON_VERSION" >/dev/null 2>&1 || true
+  # --system: without it uv answers with .venv's own interpreter, which is
+  # circular -- a stale .venv would then be judged qualified by itself.
+  uv python find --system "$MIN_PYTHON" 2>/dev/null
+}
+
+PYTHON_BIN="$(ensure_python || true)"
+if [ -z "$PYTHON_BIN" ]; then
+  log "no interpreter satisfying $MIN_PYTHON — upgrading uv and retrying"
+  # `uv self update` first because it is the supported path, but it fails on an
+  # unauthenticated GitHub API rate limit in sandboxed environments; PyPI is the
+  # fallback that works there. Either way this runs at most once.
+  uv self update >/dev/null 2>&1 || python3 -m pip install --quiet --user --upgrade uv
+  hash -r
+  PYTHON_BIN="$(ensure_python || true)"
+fi
+
+if [ -z "$PYTHON_BIN" ]; then
+  echo "FAILED: no CPython $MIN_PYTHON available and uv could not fetch one." >&2
+  echo "        homeassistant (pinned in requirements_test.txt) will not install" >&2
+  echo "        on anything older, so this is an interpreter problem, NOT a" >&2
+  echo "        broken package index." >&2
+  exit 1
+fi
+log "interpreter: $PYTHON_BIN"
+
+# --- venv ----------------------------------------------------------------------
+# Rebuild only when the existing .venv is missing or is on an interpreter that no
+# longer qualifies. Recreating a good one on every session start would throw away
+# the container's warm state for nothing.
+if [ -x .venv/bin/python ] \
+   && .venv/bin/python -c 'import sys; sys.exit(0 if sys.version_info[:3] >= (3, 14, 2) else 1)' 2>/dev/null; then
+  log ".venv already on a qualifying interpreter — keeping it"
+else
+  log "creating .venv on $PYTHON_VERSION"
+  rm -rf .venv
+  uv venv --python "$PYTHON_BIN" .venv >/dev/null
+fi
+
+log "installing requirements_test.txt"
+VIRTUAL_ENV="$PWD/.venv" uv pip install --quiet -r requirements_test.txt
+
+# --- proof ---------------------------------------------------------------------
+# Assert what the venv EXISTS to provide rather than trusting the installer's exit
+# code: every gate that shells out to python fails with ModuleNotFoundError if
+# homeassistant is absent, and that failure reads as a finding rather than as an
+# environment problem.
+.venv/bin/python - <<'PY'
+import pytest, ruff  # noqa: F401
+import sys
+from homeassistant.const import __version__ as ha_version
+
+print(f"  ready: python {'.'.join(map(str, sys.version_info[:3]))}, "
+      f"homeassistant {ha_version}")
+PY


### PR DESCRIPTION
## Why

`python3 -m venv` + pip cannot build this environment, and the way it fails sends you after the wrong problem.

`requirements_test.txt` pins `pytest-homeassistant-custom-component`, which pins `homeassistant==2026.8.2`, which declares `requires-python >=3.14.2`. Distros ship 3.10–3.13. pip does not report a too-old interpreter as such — it filters the index by `Requires-Python` and offers the newest version that *does* match (`2024.3.3` on 3.11), which reads as a stale or broken package index. It is not: PyPI is fine, the interpreter is too old.

A web session that starts with no venv hits exactly this, and the misreading costs the session.

## What

**`scripts/setup_dev_env.sh`** — mirrors `.github/workflows/test.yaml` step for step (uv → a pinned 3.14 → `requirements_test.txt` and nothing else), so the local environment and CI cannot drift. Idempotent: a `.venv` already on a qualifying interpreter is kept and its requirements re-synced.

It handles the second trap as well: a `uv` predating the 3.14 release installs `3.14.0rc2`, which is **below** 3.14.2 under PEP 440, and the only symptom is an unresolvable `homeassistant` pin — not a word about the interpreter. So the check is on the interpreter uv can actually produce, and uv is upgraded only when it cannot produce a qualifying one.

It ends by importing `homeassistant` rather than trusting the installer's exit code: every gate that shells out to python fails with `ModuleNotFoundError` when it is absent, and that failure reads as a finding rather than as a missing venv — the same false-accusation mode `resolve_pytest` and `test_count` already exist to prevent.

**`.claude/hooks/session-start.sh`** — runs it for web sessions. Synchronous on purpose: an async hook lets the first turn start before the venv exists, and a session that reaches for pytest a second too early gets a `ModuleNotFoundError` that reads as a code failure. Local checkouts exit early and are left untouched.

**`CLAUDE.md`** — an Environment setup section under Development Commands recording both traps.

## Validation

Run in this environment, which reproduces the problem (default `python3` is 3.11.15, no 3.14 on the box):

- Cold build — deleted `.venv`, ran the script: CPython 3.14.7 fetched, venv created, `homeassistant 2026.8.2` imports, exit 0.
- Re-run — keeps the existing venv, re-syncs requirements, exit 0.
- Hook — `CLAUDE_CODE_REMOTE=true .claude/hooks/session-start.sh` end-to-end, exit 0.
- `ruff check .` → all checks passed. `ruff format --check .` → 139 files already formatted.
- `pytest -q` → **1737 passed**, no skips, coverage 86% — matching CI exactly.

The local-skip branch is reasoned, not executed: this session runs with `CLAUDE_CODE_REMOTE=true`, so only the remote path could be exercised here.

## Follow-up not in this PR

The hook is committed but **not registered**. Registration needs `.claude/settings.json`:

```json
{ "hooks": { "SessionStart": [ { "hooks": [ { "type": "command",
  "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" } ] } ] } }
```

That file could not be written from this session (blocked by the permission classifier), so it is left as a deliberate manual step rather than worked around.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnbxfEFoz6ao3caV42uBXw)_