### PR TITLE
Register the SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Why

`.claude/hooks/session-start.sh` landed in #4, but nothing referenced it, so it never ran. Registration lives in `.claude/settings.json` — the one file the session that wrote the hook was not permitted to create, so it shipped as a documented manual step. This is that step.

## What

One file, `.claude/settings.json`, pointing `SessionStart` at the committed hook:

```json
{ "hooks": { "SessionStart": [ { "hooks": [ { "type": "command",
  "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" } ] } ] } }
```

With this in place a web session builds `.venv/` before its first turn, instead of meeting the failure `scripts/setup_dev_env.sh` exists to explain: `homeassistant` requires Python >=3.14.2, and on an older interpreter pip reports a two-year-old release rather than the interpreter, which reads as a broken package index.

## Validation

**The registration fired, observed.** With this file in the working tree, the authoring session's own resume triggered it, and the hook ran the script to completion:

```
SessionStart:resume hook success: interpreter: .../cpython-3.14-linux-x86_64-gnu/bin/python3.14
  .venv already on a qualifying interpreter — keeping it
  installing requirements_test.txt
  ready: python 3.14.7, homeassistant 2026.8.2
```

That is the whole mechanism end to end — settings.json resolving `$CLAUDE_PROJECT_DIR`, the hook's remote guard passing, the script finding a qualifying interpreter and re-syncing requirements — on the idempotent path rather than a cold build.

Supporting checks:

- `.claude/settings.json` parses, and the command it names resolves to the hook committed in #4, which is present and executable (`-rwxr-xr-x`).
- The cold path was exercised in #4: `.venv` deleted, CPython 3.14.7 fetched, `1737 passed`, clean `ruff check` and `ruff format --check`.
- Nothing here touches integration code, so this diff cannot change the suite's result; CI on this PR confirms that.
