### PR TITLE
s22: sensor.py filtered the mapped value, so 27 of 31 ENUM sensors leaked

### DIFF
--- a/custom_components/rivian/binary_sensor.py
+++ b/custom_components/rivian/binary_sensor.py
@@ -95,7 +95,7 @@ class RivianBinarySensorEntity(RivianVehicleEntity, BinarySensorEntity):
             return any(self._get_value(entity_key) in values for entity_key in fields)
         if (val := self._get_value(fields)) is not None:
             # A value the vehicle flags as unusable is not a state -- report
-            # unknown, mirroring sensor.py:184.
+            # unknown, mirroring sensor.py:205.
             #
             # This matters more here than it does for a sensor. A sensor showing
             # "SNA" at least looks wrong; a binary sensor silently resolves it,

--- a/custom_components/rivian/coordinator.py
+++ b/custom_components/rivian/coordinator.py
@@ -1384,7 +1384,7 @@ class VehicleCoordinator(RivianDataUpdateCoordinator[dict[str, Any]]):
                         # Dropping it here instead was tried and reverted: it
                         # made entities unavailable rather than show a
                         # stale-but-plausible state, which takes the matching
-                        # control down with the sensor (sensor.py:172-179,
+                        # control down with the sensor (sensor.py:186,
                         # binary_sensor.py:110).
                         self._note_unusable(k, value)
                     # `history` is a set, so an unhashable value (decode_vehicle_wheels

--- a/custom_components/rivian/sensor.py
+++ b/custom_components/rivian/sensor.py
@@ -167,8 +167,19 @@ class RivianSensorEntity(RivianVehicleEntity, SensorEntity):
         if (val := self._get_value(self.entity_description.field)) is None:
             return STATE_UNAVAILABLE if not self.native_unit_of_measurement else None
 
-        rval = _fn(val) if (_fn := self.entity_description.value_lambda) else val
         # A value the vehicle flags as unusable is not a state -- report unknown.
+        #
+        # Tested on the RAW value, BEFORE value_lambda runs, exactly as
+        # binary_sensor.py's is_on does. It used to test the lambda's OUTPUT, and
+        # that let three of the four spellings through: most lambdas run
+        # _to_title_case, which turns underscores into spaces, so
+        # "signal_not_available" arrived here as "signal not available" and
+        # matched nothing in the set. 27 of the 31 ENUM sensors leaked that way.
+        #
+        # All four spellings are the app's own -- p069Ci/EnumC0996d.java declares
+        # FAULT, SIGNAL_NOT_AVAILABLE, SNA and UNDEFINED as distinct constants --
+        # so INVALID_SENSOR_STATES is already right. Only the comparison point
+        # was wrong.
         #
         # This is the right layer for it. Suppressing it in the coordinator was
         # tried twice and is wrong: the raw value has to keep flowing, because
@@ -181,6 +192,16 @@ class RivianSensorEntity(RivianVehicleEntity, SensorEntity):
         # Without this, the branch below appends "SNA" to the entity's own options
         # list, so the vehicle's error code silently becomes a valid state for the
         # life of the process, and the select beside it shows "unknown".
+        if str(val).lower() in INVALID_SENSOR_STATES:
+            return None
+
+        rval = _fn(val) if (_fn := self.entity_description.value_lambda) else val
+        # Pre-existing, and kept deliberately. Probing every lambda over its own
+        # declared options plus the common wire spellings found ZERO cases where
+        # a valid input produces an invalid-looking output, so this is defensive
+        # rather than load-bearing -- but that probe is sampling, not proof, and
+        # this check predates the raw one above. Safe to delete only with an
+        # argument stronger than "the probe found nothing".
         if str(rval).lower() in INVALID_SENSOR_STATES:
             return None
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -98,6 +98,20 @@ Listed so you don't go hunting for renames that never happened:
 the port has five meaningful states and a boolean can only carry one question about them. This
 mirrors `powerState`, which has carried both a binary sensor and a sensor for some time.
 
+## Behaviour change: SNA now renders as `unknown`, not "Unknown"
+
+Sensors whose value mapping *rescued* an unusable vehicle value no longer do. `charge_port_status`
+and `power_state` mapped `sna` to the literal string `"Unknown"`; both now return Home Assistant's
+native `unknown` state instead.
+
+No entity ID changes. What changes is that a template comparing `states(...) == 'Unknown'` stops
+matching — use `is_state(..., 'unknown')`, or better `states(...) in ['unknown', 'unavailable']`.
+
+This is the visible half of a wider fix: `sensor.py` was testing the *mapped* value against the
+invalid-state list instead of the raw one, so `signal_not_available` slipped through on 27 of 31
+sensors and each one appended that bogus value to its own options list. See
+[`docs/development/SENSOR_INVALID_STATE_ORDERING.md`](development/SENSOR_INVALID_STATE_ORDERING.md).
+
 ## Behaviour change without an entity change
 
 Doors, windows and closures previously reported **Closed** for any value other than the exact

--- a/docs/development/SENSOR_INVALID_STATE_ORDERING.md
+++ b/docs/development/SENSOR_INVALID_STATE_ORDERING.md
@@ -1,0 +1,69 @@
+# The two platforms must filter the same value at the same point
+
+`sensor.py` and `binary_sensor.py` both drop values the vehicle flags as unusable —
+`INVALID_SENSOR_STATES` (`const.py`) = `{fault, signal_not_available, sna, undefined}`. They
+disagreed about *when*, and that disagreement was a bug.
+
+## What went wrong
+
+`binary_sensor.py` tests the **raw** value. `sensor.py` tested the **output of `value_lambda`**.
+
+Most lambdas run `_to_title_case`, which converts underscores to spaces:
+
+```
+"signal_not_available"  ->  "Signal Not Available"  ->  .lower() == "signal not available"
+```
+
+Spaces, not underscores. That matches nothing in the set, so it slipped past the filter, failed
+the ENUM `options` check below it, logged an error, and — the real damage —
+**appended itself to that entity's own `options` list for the life of the process**. The vehicle's
+error code became a permanently valid state for that entity.
+
+Measured before the fix: **27 of the 31** options-carrying sensors leaked on
+`signal_not_available`. Every `*_next_action` closure sensor, `charger_status`, `ota_status`,
+`trailer_status`, `power_state`, and all nine seat heat/vent sensors. `sensor.py`'s own comment
+notes the rear seat heaters report SNA whenever the vehicle is parked, so this was not exotic.
+
+## Why the constant was already right
+
+The app is normative and it agrees with us. `java_src/p069Ci/EnumC0996d.java` declares all four as
+distinct constants:
+
+```java
+public static final String FAULT                = "Fault";
+public static final String SIGNAL_NOT_AVAILABLE = "signal_not_available";
+public static final String SNA                  = "sna";
+public static final String UNDEFINED            = "undefined";
+```
+
+So `signal_not_available` genuinely occurs on the wire — the leak was real, not theoretical — and
+`INVALID_SENSOR_STATES` needs no members added or removed. Only the comparison point was wrong.
+
+Note the app capitalizes `FAULT` as `"Fault"`. Our comparison lowercases first, so this is already
+handled. Do **not** "fix" the constant to match the capitalization; that would be a deviation from
+the app for no gain.
+
+`VehicleStateKt.isSignalNotAvailable` compares against `"-1"`, but that is the numeric cellular
+signal field, not the state vocabulary. Do not conflate the two.
+
+## The fix
+
+`sensor.py` now tests the raw value **before** `value_lambda` runs, mirroring `binary_sensor.py`.
+The post-lambda test is kept as well — it costs nothing and still catches a lambda that
+manufactures an invalid-looking string from a valid input.
+
+## The behaviour change this causes
+
+A lambda that *rescued* an invalid value no longer gets the chance. `charge_port_status` and
+`power_state` both map `sna` to the literal string `"Unknown"`; they now return `None`, which
+renders as Home Assistant's native `unknown` state.
+
+That is the point — a vehicle error code should not be dressed up as a state — but it is visible
+on a dashboard, so it is recorded in `docs/MIGRATION.md`.
+
+## What pins this
+
+`tests/test_sensor_invalid_state_ordering.py` walks **every** options-carrying description and
+asserts each spelling resolves to `None` and that `options` is never mutated. It pins the class,
+not the instance: a new ENUM sensor is covered without anyone remembering to add a case. It also
+asserts the population size, so a sensor cannot quietly leave the guarantee.

--- a/scripts/gates/helpers/code_anchors.tsv
+++ b/scripts/gates/helpers/code_anchors.tsv
@@ -16,11 +16,11 @@ custom_components/rivian/rivian_client/rivian.py	raise err_cls(response.status, 
 custom_components/rivian/rivian_client/rivian.py	"Error occurred while reading the graphql response from Rivian.",	custom_components/rivian/rivian_client/exceptions.py	91d3a804be55	the five-positional-argument raise site (ERROR_CODE_CLASS_MAP fallback)
 custom_components/rivian/rivian_client/rivian.py	raise err_cls(response.status, response_json, headers, body)	custom_components/rivian/rivian_client/exceptions.py	11b1e1adbbdc	second mention of the four-arg site
 custom_components/rivian/rivian_client/rivian.py	"Error occurred while reading the graphql response from Rivian.",	custom_components/rivian/rivian_client/exceptions.py	75ea01bf155a	second mention of the five-arg site
-custom_components/rivian/sensor.py	if str(rval).lower() in INVALID_SENSOR_STATES:	custom_components/rivian/binary_sensor.py	3d2ca2ea3e9b	off by one: sensor.py's INVALID_SENSOR_STATES check is :184, not :183
+custom_components/rivian/sensor.py	if str(rval).lower() in INVALID_SENSOR_STATES:	custom_components/rivian/binary_sensor.py	c100b8e20f42	off by one: sensor.py's INVALID_SENSOR_STATES check is :184, not :183
 custom_components/rivian/binary_sensor.py	if str(val).lower() in INVALID_SENSOR_STATES:	custom_components/rivian/switch.py	88d6970dcb2f	binary_sensor.py's INVALID_SENSOR_STATES check
 custom_components/rivian/binary_sensor.py	if str(val).lower() in INVALID_SENSOR_STATES:	custom_components/rivian/switch.py	4151485ecfa7	second mention, same target
 custom_components/rivian/rivian_client/parallax.py	_CLIMATE_HOLD_STATUS = {	custom_components/rivian/switch.py	4151485ecfa7	the climateHoldStatus decode table
-custom_components/rivian/sensor.py	RivianVehicleEntity.available is driven by the field being present, and	custom_components/rivian/coordinator.py	01b4a9094b69	sensor.py's matching-control-down-with-sensor paragraph
+custom_components/rivian/sensor.py	RivianVehicleEntity.available is driven by the field being present, and	custom_components/rivian/coordinator.py	b727e28628c2	sensor.py's matching-control-down-with-sensor paragraph
 custom_components/rivian/binary_sensor.py	Returning None yields `unknown`, NOT `unavailable` --	custom_components/rivian/coordinator.py	5ccc95e7946a	binary_sensor.py's matching-control-down-with-sensor paragraph
 custom_components/rivian/update.py	current_version = self._get_value("otaCurrentVersion")	custom_components/rivian/const.py	4617e4d416b2	update.py's installed/latest-version construction
 custom_components/rivian/__init__.py	coor.async_config_entry_first_refresh()	custom_components/rivian/cover.py	d56688f2aeb4	the per-vehicle coordinator's first refresh

--- a/tests/test_sensor_invalid_state_ordering.py
+++ b/tests/test_sensor_invalid_state_ordering.py
@@ -1,0 +1,99 @@
+"""`sensor.py` and `binary_sensor.py` must filter the same value at the same point.
+
+They did not. `binary_sensor.py` tested the RAW value against `INVALID_SENSOR_STATES`;
+`sensor.py` tested the OUTPUT of `value_lambda`. Most lambdas run `_to_title_case`,
+which turns underscores into spaces, so `signal_not_available` reached the check as
+`"signal not available"` and matched nothing in the set. It then failed the ENUM
+options check, logged an error, and appended itself to that entity's own `options`
+list for the life of the process.
+
+**27 of the 31** options-carrying sensors leaked that way. This file pins the class,
+not the instance: a new ENUM sensor added tomorrow is covered without anyone
+remembering to add a case.
+
+All four spellings are the app's own -- `java_src/p069Ci/EnumC0996d.java` declares
+`FAULT`, `SIGNAL_NOT_AVAILABLE`, `SNA` and `UNDEFINED` as distinct constants -- so
+`INVALID_SENSOR_STATES` was already correct and APK-aligned. Only the comparison
+point was wrong. Do not "fix" the constant.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.rivian.const import INVALID_SENSOR_STATES, SENSORS
+from custom_components.rivian.sensor import RivianSensorEntity
+
+DESCRIPTIONS = {d.key: d for group in SENSORS.values() for d in group}
+WITH_OPTIONS = sorted(k for k, d in DESCRIPTIONS.items() if getattr(d, "options", None))
+
+
+class _FakeSensor:
+    """The narrowest object `native_value` actually touches."""
+
+    def __init__(self, description: Any, value: Any) -> None:
+        self.entity_description = description
+        self._value = value
+        self.entity_id = f"sensor.fake_{description.key}"
+        self.unique_id = self.entity_id
+        self.options = list(description.options or [])
+        self.device_class = description.device_class
+        self.native_unit_of_measurement = description.native_unit_of_measurement
+
+    def _get_value(self, _field: Any) -> Any:
+        return self._value
+
+
+def _native_value(description: Any, value: Any) -> Any:
+    return RivianSensorEntity.native_value.fget(_FakeSensor(description, value))
+
+
+class TestNoInvalidSpellingReachesTheOptionsCheck:
+    """The property, stated once, for every sensor that has options."""
+
+    def test_the_population_is_what_we_think_it_is(self) -> None:
+        """Guards the parametrization below against silently shrinking."""
+        assert len(WITH_OPTIONS) == 31, WITH_OPTIONS
+
+    @pytest.mark.parametrize("key", WITH_OPTIONS)
+    @pytest.mark.parametrize("spelling", sorted(INVALID_SENSOR_STATES))
+    def test_invalid_spelling_resolves_to_none(self, key: str, spelling: str) -> None:
+        """Every spelling the app can emit must resolve to `unknown`, not a state.
+
+        Returning None yields HA's native `unknown`. The failure this replaces was
+        worse than a wrong label: the entity MUTATED its own options list, so the
+        vehicle's error code became a permanently valid state for that process.
+        """
+        assert _native_value(DESCRIPTIONS[key], spelling) is None, f"{key} / {spelling}"
+
+    @pytest.mark.parametrize("key", WITH_OPTIONS)
+    def test_options_are_never_mutated_by_an_invalid_value(self, key: str) -> None:
+        """The append is the real damage; assert it never happens."""
+        description = DESCRIPTIONS[key]
+        entity = _FakeSensor(description, "signal_not_available")
+        before = list(entity.options)
+        RivianSensorEntity.native_value.fget(entity)
+        assert entity.options == before, key
+
+
+class TestOrderingMatchesBinarySensor:
+    """The raw value is tested BEFORE the lambda, not after."""
+
+    def test_a_lambda_that_would_rescue_an_invalid_value_does_not_get_to(self) -> None:
+        """`charge_port_status` maps every invalid spelling to "Unknown".
+
+        That mapping is fine and stays -- but it must never be what decides the
+        outcome, because a lambda that rescues an invalid value is exactly how the
+        old ordering hid the bug. The raw check has to win first.
+        """
+        description = DESCRIPTIONS["charge_port_status"]
+        assert description.value_lambda("signal_not_available") == "Unknown"
+        assert _native_value(description, "signal_not_available") is None
+
+    def test_valid_values_still_pass_through_the_lambda(self) -> None:
+        """The fix must not break the normal path."""
+        description = DESCRIPTIONS["charge_port_status"]
+        assert _native_value(description, "in_transition") == "In Transition"
+        assert _native_value(description, "close") == "Close"


### PR DESCRIPTION
> **Stacked on #6.** Base is `s21-binary-sensor-apk-parity` because this needs `charge_port_status` to exist to be testable. GitHub retargets to `master` when #6 merges.

## The bug

`sensor.py` computed `rval = value_lambda(val)` and **then** tested it against `INVALID_SENSOR_STATES`. Most lambdas run `_to_title_case`, which turns underscores into spaces:

```
"signal_not_available"  →  "Signal Not Available"  →  .lower() == "signal not available"
```

Spaces, not underscores — matching nothing in the set. It missed the filter, failed the ENUM options check below it, logged an error, and **appended itself to that entity's own `options` list for the life of the process**. The vehicle's error code became a permanently valid state for that entity.

`binary_sensor.py` has always tested the **raw** value. The two platforms disagreed; `sensor.py` was the one that was wrong.

## Scale

Measured, not guessed: **27 of the 31** options-carrying sensors leaked — every `*_next_action` closure sensor, `charger_status`, `ota_status`, `trailer_status`, `power_state`, and all nine seat heat/vent sensors. `sensor.py`'s own comment notes the rear seat heaters report SNA whenever the vehicle is parked, so this was not exotic.

After the fix the same scan reports **0**.

## The APK says the constant was already right

`java_src/p069Ci/EnumC0996d.java` declares all four as distinct constants:

```java
public static final String FAULT                = "Fault";
public static final String SIGNAL_NOT_AVAILABLE = "signal_not_available";
public static final String SNA                  = "sna";
public static final String UNDEFINED            = "undefined";
```

So `signal_not_available` genuinely occurs on the wire — the leak was real, not theoretical — and `INVALID_SENSOR_STATES` needs no member added or removed. Only the comparison point was wrong. The app capitalizes `FAULT` as `"Fault"`; we lowercase before comparing, so that is handled and must **not** be "fixed".

## ⚠️ Behaviour change

A lambda that *rescued* an invalid value no longer gets to. `charge_port_status` and `power_state` mapped `sna` to the literal string `"Unknown"`; both now return `None`, rendering as HA's native `unknown`. That is the intent — an error code should not be dressed up as a state — but a dashboard can see it. Recorded in [docs/MIGRATION.md](docs/MIGRATION.md).

## On the retained second check

The post-lambda check stays. Probing every lambda over its declared options plus the common wire spellings found **zero** cases where a valid input yields an invalid-looking output, so it is defensive rather than load-bearing — but that is sampling, not proof, and it predates this change. Removing it needs a better argument than "the probe found nothing."

## Verification

- 2094 tests pass (+158 new)
- The new tests pin the **class**: every options-carrying description × every spelling, plus an assertion that `options` is never mutated. A new ENUM sensor is covered without anyone remembering to add a case.
- `ruff` clean, `dump_entity_sets.py --check` passes, f11 citation gate passes

Background: [docs/development/SENSOR_INVALID_STATE_ORDERING.md](docs/development/SENSOR_INVALID_STATE_ORDERING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019snZp51sXq4nFGLyn9FE33
