### PR TITLE
s23: cutting a release is now a deliberate act

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,10 +1,15 @@
 name: Pre-Release Build
 
+# Manual only. This used to fire on every push to master, which meant a merge
+# published a beta before its own test run had finished -- and, once master became
+# protected, the version-bump step at the end could no longer push. That push was
+# rejected with GH006 and swallowed by `|| echo "Push skipped"`, so the workflow
+# reported success while the bump silently vanished and the next run would have
+# recomputed the same version and collided with an existing tag.
+#
+# Cutting a release is now a deliberate act: bump the version in a normal PR, then
+# run this workflow.
 on:
-  push:
-    branches:
-      - master
-      - master-*
   workflow_dispatch:
 
 jobs:
@@ -26,45 +31,23 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Current version: $VERSION"
 
-      - name: Calculate next pre-release version
-        id: next_version
+      - name: Refuse to re-cut an existing tag
         run: |
-          CURRENT="${{ steps.current_version.outputs.version }}"
-
-          # Extract base version and beta number
-          # Pattern: X.Y.Z-betaN or X.Y.Z
-          if [[ "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-beta([0-9]+)$ ]]; then
-            BASE="${BASH_REMATCH[1]}"
-            BETA_NUM="${BASH_REMATCH[2]}"
-            NEXT_BETA=$((BETA_NUM + 1))
-            NEXT_VERSION="${BASE}-beta${NEXT_BETA}"
-          elif [[ "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-            # No beta suffix, start at beta1
-            BASE="${BASH_REMATCH[1]}"
-            NEXT_VERSION="${BASE}-beta1"
-          else
-            echo "Error: Unable to parse version: $CURRENT"
+          VERSION="${{ steps.current_version.outputs.version }}"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION already exists. Bump the version in a PR before releasing."
             exit 1
           fi
+          echo "Releasing $VERSION"
 
-          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
-          echo "Next version: $NEXT_VERSION"
-
-      - name: Update version in files
+      - name: Check the two version strings agree
         run: |
-          NEXT_VERSION="${{ steps.next_version.outputs.next_version }}"
-
-          # Update manifest.json
-          jq --arg v "$NEXT_VERSION" '.version = $v' custom_components/rivian/manifest.json > tmp.json
-          mv tmp.json custom_components/rivian/manifest.json
-
-          # Update const.py if VERSION is defined
-          if grep -q "^VERSION = " custom_components/rivian/const.py 2>/dev/null; then
-            sed -i "s/^VERSION = .*/VERSION = \"$NEXT_VERSION\"/" custom_components/rivian/const.py
+          VERSION="${{ steps.current_version.outputs.version }}"
+          CONST=$(sed -n 's/^VERSION = "\(.*\)"/\1/p' custom_components/rivian/const.py)
+          if [ -n "$CONST" ] && [ "$CONST" != "$VERSION" ]; then
+            echo "::error::manifest.json says $VERSION but const.py says $CONST"
+            exit 1
           fi
-
-          echo "Updated to version: $NEXT_VERSION"
-          cat custom_components/rivian/manifest.json
 
       - name: Create zip package
         # Allow-list, not a bare recursive zip. This workflow fires on every push
@@ -86,12 +69,12 @@ jobs:
       - name: Create or update pre-release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.next_version.outputs.next_version }}
-          name: "Pre-release ${{ steps.next_version.outputs.next_version }}"
+          tag_name: ${{ steps.current_version.outputs.version }}
+          name: "Pre-release ${{ steps.current_version.outputs.version }}"
           body: |
             ## Pre-release Build
 
-            **Version:** ${{ steps.next_version.outputs.next_version }}
+            **Version:** ${{ steps.current_version.outputs.version }}
             **Branch:** ${{ github.ref_name }}
             **Commit:** ${{ github.sha }}
 
@@ -104,14 +87,3 @@ jobs:
           files: rivian.zip
           prerelease: true
           generate_release_notes: true
-
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add custom_components/rivian/manifest.json
-          if [ -f custom_components/rivian/const.py ]; then
-            git add custom_components/rivian/const.py
-          fi
-          git commit -m "chore: bump version to ${{ steps.next_version.outputs.next_version }} [skip ci]" || echo "No changes to commit"
-          git push || echo "Push skipped (likely no changes)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,17 @@ straight to `master`, including for a one-line doc fix.
 (`s21-binary-sensor-apk-parity`). The `sNN:` commit prefix delineates one story from the next, and
 the branch boundary agrees with it.
 
-**Commit prefixes** use the repo's `sNN:` story convention. Version bumps are CI-owned
-(`chore: bump version [skip ci]`) — never bump by hand.
+**Commit prefixes** use the repo's `sNN:` story convention.
+
+**Releases are cut by hand, and so are version bumps.** Bump `manifest.json` *and* `const.py`'s
+`VERSION` in a normal PR, then run the **Pre-Release Build** workflow manually
+(`workflow_dispatch`). It tags exactly what the manifest says and refuses to re-cut an existing
+tag.
+
+This replaces a CI-owned bump (`chore: bump version [skip ci]`) that fired on every push to
+master. Protecting `master` broke it: the bot's push was rejected with `GH006` and swallowed by
+`|| echo "Push skipped"`, so the workflow reported success while the bump vanished. It also meant
+a merge published a beta before its own test run had finished.
 
 **Pre-commit needs `.venv/bin` on PATH** or commits fail with "pre-commit not found". Fix the PATH;
 never reach for `--no-verify`. One of its hooks is `f11`, which checks that every `file.py:NN`

--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -27,7 +27,7 @@ from .data_classes import (
 
 NAME = "Rivian (Unofficial)"
 DOMAIN = "rivian"
-VERSION = "1.6.0-beta15"
+VERSION = "1.6.0-beta16"
 ISSUE_URL = "https://github.com/bretterer/home-assistant-rivian/issues"
 
 # Attributes

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "bleak>=0.21"
   ],
-  "version": "1.6.0-beta15"
+  "version": "1.6.0-beta16"
 }


### PR DESCRIPTION
## Why

Protecting `master` silently broke the version bump, and beta16 shipped without it.

The workflow's last step pushed a `chore: bump version` commit straight to master. That push is now rejected:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
 ! [remote rejected] master -> master (protected branch hook declined)
```

The line was `git push || echo "Push skipped (likely no changes)"`, so the failure was swallowed and **the run reported success**. Consequences: master's manifest still said `beta15` while `beta16` was published, and the next merge would have recomputed `beta16` and collided with the existing tag. The message was also the opposite of the truth — there *were* changes; the push was refused.

**It also published before its own tests finished.** beta16 was released 12s after the merge while the Tests run on master was still `in_progress` — the artifact beta users install was never gated on a green suite.

## What changed

Rather than working around protection with a bypass token or a bot PR, the auto-cut is removed:

- **`workflow_dispatch` only** — no more firing on every push to master
- **The manifest is the single source of truth.** Nothing is computed or incremented; the tag is exactly what `manifest.json` says
- **The bump step is gone.** Bumping is a human PR now
- **Two new guards:** refuse to re-cut an existing tag, and refuse if `manifest.json` and `const.py` disagree

## Housekeeping in the same PR

`manifest.json` and `const.py` go to `1.6.0-beta16`, so the repo stops disagreeing with what is actually published — this is the bump beta16's own run failed to commit, applied by hand.

`CLAUDE.md`'s "version bumps are CI-owned — never bump by hand" is now exactly backwards and has been rewritten.

## The new release process

1. Bump `manifest.json` **and** `const.py`'s `VERSION` in a normal PR (next one is `beta17`)
2. Merge it
3. Run **Pre-Release Build** manually

## Verification

2096 tests pass, ruff clean, f11 37/0. The workflow parses as valid YAML with a single `workflow_dispatch` trigger and no remaining references to the removed computed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019snZp51sXq4nFGLyn9FE33
