### PR TITLE
s24: bump to 1.6.0-beta17 for the first hand-cut release

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -27,7 +27,7 @@ from .data_classes import (
 
 NAME = "Rivian (Unofficial)"
 DOMAIN = "rivian"
-VERSION = "1.6.0-beta16"
+VERSION = "1.6.0-beta17"
 ISSUE_URL = "https://github.com/bretterer/home-assistant-rivian/issues"
 
 # Attributes

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "bleak>=0.21"
   ],
-  "version": "1.6.0-beta16"
+  "version": "1.6.0-beta17"
 }


### PR DESCRIPTION
> **Depends on #8.** Based on `s23-manual-release-cut` so the diff shows only the bump — it touches the same two version lines #8 does, and basing it on `master` would conflict. GitHub retargets this to `master` when #8 merges.

## What

The first version bump under the process #8 introduces: a human moves the version in a PR, then dispatches Pre-Release Build by hand.

| file | from | to |
|---|---|---|
| `custom_components/rivian/manifest.json` | `1.6.0-beta16` | `1.6.0-beta17` |
| `custom_components/rivian/const.py:30` | `1.6.0-beta16` | `1.6.0-beta17` |

Both move together because #8 added a guard that fails the release if they disagree. Nothing else in the tree pins the version.

## Why beta17 and not beta16

#8 set both files to `beta16` so the repo would stop disagreeing with what was already published. But under the new workflow the manifest names the version **about to be cut**, and the release refuses to re-cut an existing tag — so left at `beta16`, no release could be dispatched at all.

## Checked against both of #8's guards

- the two version strings agree
- `1.6.0-beta17` is not an existing tag

2096 tests pass, ruff clean.

## Release order

1. Merge #8 — **first**, so the old auto-cut is gone before any bump lands on master
2. Merge this
3. Run **Pre-Release Build** manually → cuts `1.6.0-beta17`

Merging this before #8 would fire the old auto-cut on master and consume the version number automatically — the exact behaviour #8 removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019snZp51sXq4nFGLyn9FE33
