### PR TITLE
s24: bump to 1.6.0-beta17 for the first hand-cut release

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -27,7 +27,7 @@ from .data_classes import (
 
 NAME = "Rivian (Unofficial)"
 DOMAIN = "rivian"
-VERSION = "1.6.0-beta16"
+VERSION = "1.6.0-beta17"
 ISSUE_URL = "https://github.com/bretterer/home-assistant-rivian/issues"
 
 # Attributes

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "bleak>=0.21"
   ],
-  "version": "1.6.0-beta16"
+  "version": "1.6.0-beta17"
 }


### PR DESCRIPTION
Re-opened against `master`. #9 was based on `s23-manual-release-cut`, so merging it moved the bump into that branch rather than onto master — and #8 had already merged 10 seconds earlier, so the branch it landed in was already consumed. My stacking choice, my mistake.

This is the same single commit, now targeting `master` directly.

| file | from | to |
|---|---|---|
| `custom_components/rivian/manifest.json` | `1.6.0-beta16` | `1.6.0-beta17` |
| `custom_components/rivian/const.py:30` | `1.6.0-beta16` | `1.6.0-beta17` |

## Why this is needed before a release can be cut

Master currently says `beta16`, and that tag already exists. #8's guard correctly refuses to re-cut it, so **no release can be dispatched until this lands**:

```
::error::Tag 1.6.0-beta16 already exists. Bump the version in a PR before releasing.
```

Both of #8's guards check out against this bump: the two version strings agree, and `1.6.0-beta17` is not an existing tag.

## After merging

Run **Pre-Release Build** manually → cuts `1.6.0-beta17`, the first release carrying the ajar fix and both SNA fixes.

Merging this is now safe in any order — the old auto-cut is gone from master as of #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019snZp51sXq4nFGLyn9FE33
