### PR TITLE
s29: bump to 1.6.0-beta18 for the Gear Guard live camera

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -27,7 +27,7 @@ from .data_classes import (
 
 NAME = "Rivian (Unofficial)"
 DOMAIN = "rivian"
-VERSION = "1.6.0-beta17"
+VERSION = "1.6.0-beta18"
 ISSUE_URL = "https://github.com/bretterer/home-assistant-rivian/issues"
 
 # Attributes

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "bleak>=0.21"
   ],
-  "version": "1.6.0-beta17"
+  "version": "1.6.0-beta18"
 }


### PR DESCRIPTION
Version bump only — `manifest.json` and `const.py` together, which the Pre-Release Build workflow checks agree before it will tag.

First beta carrying the Gear Guard live camera work merged in #13:

- KVS ICE servers prefetched before the offer, so the browser builds its peer connection with a real TURN relay instead of host candidates the vehicle cannot reach.
- The card's ICE candidates buffered until the session id arrives, instead of being dropped.
- The offer kept under the AWS KVS 10,000-byte signaling limit — by pinning H264 in the bundled card, and by trimming server-side for HA's built-in player, which cannot be told to offer less.

Both viewer paths were verified streaming on a live vehicle before #13 merged: the bundled card at a 4678-byte offer, and HA's built-in player at 8398 trimmed to 5417, both connected over H264 with frames decoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011V1EUYktxPdCyhxJ4rwy7p