### PR TITLE
s27: an HA-shaped catalog of what APK 3.15.0 still has and we do not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,8 @@ docs/development/apk/*.java
 
 # gh-sweep: salt for community fixture vehicle-fingerprint digests (never commit)
 tests/fixtures/community/.salt
+
+# APK MITM capture artifacts — may contain session tokens even with redaction.
+# Patched-APK output and frida-server binaries need no rule: `.apk/` above
+# already covers them.
+captures/apk_mitm/

--- a/custom_components/rivian/rivian_client/const.py
+++ b/custom_components/rivian/rivian_client/const.py
@@ -314,9 +314,9 @@ class VehicleCommand(StrEnum):
     ENABLE_GEAR_GUARD_VIDEO = "ENABLE_GEAR_GUARD_VIDEO"
     DISABLE_GEAR_GUARD = "DISABLE_GEAR_GUARD"
     DISABLE_GEAR_GUARD_VIDEO = "DISABLE_GEAR_GUARD_VIDEO"
-    # VASCommand.StartGearGuardMasterSession at :1350. Declared, not wired: it
-    # starts a live camera session, which is a streaming feature this integration
-    # has no surface for, not a control. Kept so the name is recorded.
+    # VASCommand.StartGearGuardMasterSession at :1350. Wired by s28 as
+    # camera.gear_guard_live in camera.py -- a live-view path, not a control.
+    # Tear-down is local; the app declares no stop command.
     START_GEAR_GUARD_MASTER_SESSION = "START_GEAR_GUARD_MASTER_SESSION"
 
     # Liftgate (R1S only)

--- a/docs/development/COMMAND_COVERAGE.md
+++ b/docs/development/COMMAND_COVERAGE.md
@@ -19,6 +19,8 @@ f2 added `CABIN_HVAC_3RD_ROW_REAR_{LEFT,RIGHT}_SEAT_HEAT`; f6 added
 
 ## In the enum but deliberately not wired to an entity
 
+HA-shaped remaining-gap dispositions live in [`REMAINING_APK_GAPS.md`](REMAINING_APK_GAPS.md). This table remains the probe record.
+
 | Command | Why |
 |---|---|
 | `OPEN_LIFTGATE` | Wired as `button.open_liftgate`, **disabled by default** — it moves a closure and has not been actuated (f7) |
@@ -119,6 +121,23 @@ three separate ways now:
 Stamping a dated "deprecated" note on these would write false provenance and
 defeat the next person's instinct to re-check. Removal requires a recorded live
 failure.
+
+**Unlock-family live probes, 2026-08-26 ~11:53 UTC** (power Ready, Park, closures
+locked, windows closed; `OPEN_TAILGATE` not sent). Same session style as the
+cheap-candidate run: HMAC working — other commands on this account accept.
+
+| Command | Result | Restore |
+|---|---|---|
+| `UNLOCK_DRIVER_DOOR` | **REJECTED** `CONFLICT/VEHICLE_COMMAND_ERROR` (no command id, 0.77 s) | not needed |
+| `UNLOCK_PASSENGER_DOOR` | **REJECTED** same (0.63 s) | not needed |
+| `UNLOCK_USER_PREFERENCES_AND_DISABLE_ALARM` | **REJECTED** same (0.79 s) | not needed |
+| `UNLOCK_ALL_AND_OPEN_WINDOWS` | **REJECTED** same (0.72 s) | not needed |
+
+Post-run: lock still locked, windows still closed, alarm switch still off.
+No lock restore ran because nothing unlocked. Same class as
+`HONK_AND_FLASH_LIGHTS` (also APK-absent, also CONFLICT). Kept in the enum.
+Tonneau's "absence from the app is not evidence of absence" still holds for
+those two; it does not make these four sendable on this VAS path.
 
 
 ## f7 results, 2026-08-19 (beta6)
@@ -254,6 +273,57 @@ as command-specific. **What is not verified**: that these two explain
 `HONK_AND_FLASH_LIGHTS`'s refusal, or that any succession or retirement
 occurred between it and this pair — consistent with that reading, not
 evidence for it.
+
+## Cheap-candidate probes, 2026-08-26 ~11:18 UTC
+
+Sent with `scripts/probe_vehicle_command.py` against this 2022 R1T (`…002984`).
+Pre-flight (HA entities via supervisor core socket): `powerState` Sleep,
+`gearGuardLocked` unlocked, climate-hold switch off / status Available, Park,
+closures locked. `WAKE_VEHICLE` first as a control (command id `04-4d83cdd16f8b8b23d10c`,
+state 5 / continue, no terminal in 11.18 s). HMAC/session were working: the
+climate-hold pair and `START_GEAR_GUARD_MASTER_SESSION` returned command ids
+on the same credentials seconds around the Gear Guard lock refusals.
+
+| Command | Result |
+|---|---|
+| `WAKE_VEHICLE` (control) | **ACCEPTED** — command id, state 5 (continue), no terminal in 11 s |
+| `CLIMATE_HOLD_ON` | **ACCEPTED** by gateway; terminal state **0** / `responseCode` **417** / `statusCode` 0 at t+8.97 s |
+| `CLIMATE_HOLD_OFF` | **ACCEPTED** by gateway; terminal state **0** / `responseCode` **417** / `statusCode` 0 at t+9.28 s |
+| `DISABLE_GEAR_GUARD` | **REJECTED** `CONFLICT/VEHICLE_COMMAND_ERROR` — no command id. Retried after `ENABLE` rejected the same way |
+| `ENABLE_GEAR_GUARD` | **REJECTED** `CONFLICT/VEHICLE_COMMAND_ERROR` — no command id |
+| `START_GEAR_GUARD_MASTER_SESSION` | **ACCEPTED** by gateway (id `04-9adefad40f5ff1e78f74`); terminal **state 4** / `responseCode` **1031** at t+4.37 s |
+
+Post-run HA: power Ready; climate-hold still off / Available; Gear Guard still
+unlocked. No closure moved. `417` and `1031` are recorded as integers; the
+decompile artifacts under `docs/development/apk/` do not name them.
+
+**Climate-hold VAS is the same class as `ACTIVATE_EXTERNAL_SOUND`:** gateway
+accept, then a vehicle-level decline. The working write remains Parallax
+(`switch.py:69-93`). Hold state did not change. Already-at-parity stays.
+
+**Gear Guard lock is the same class as `HONK_AND_FLASH_LIGHTS` / `PET_COMFORT_ON`:**
+gateway `CONFLICT` with no command id, on a session that accepted other commands
+seconds apart. Video (`ENABLE_GEAR_GUARD_VIDEO`) stays the wired path. Catalog:
+listed-not-built until a live accept — Principle -1, a VAS CONFLICT is not a
+capability failure.
+
+**`START_GEAR_GUARD_MASTER_SESSION` is a real cloud command**, and s28 went on to
+wire it as `camera.gear_guard_live` — see
+[`## START_GEAR_GUARD_MASTER_SESSION (wired s28)`](#start_gear_guard_master_session-wired-s28)
+above. State 4 is terminal (`{0,4,6,7}`).
+
+This run is the negative control for that section's claim that `params.camera` is
+required, and it is worth keeping for exactly that reason. It sent **no**
+`params.camera` and got state 4 / `1031` with no live-config frame; the s28 gate
+run sent `camera=left` and got a full `gearGuardLiveConfig`. Two runs, one
+variable, opposite outcomes — which makes "the camera param is required" a
+measurement rather than an inference.
+
+**`FLASH_EXTERNAL_LIGHTS` reproduced 2026-08-26 ~11:26 UTC** (power Ready, same
+credentials as the table above). Command id `04-678b1c2506540fd2bdee`, send ack
+0.69 s, state 2 then 3 (continue set). **No terminal state in 26.35 s**, same
+shape as 2026-08-22 (then in-flight at 9.66 s). Gateway accept is confirmed a
+second time. Vehicle decline (`412`) did **not** appear. Candidate-to-build.
 
 ## How the app reads a command's result — it SUBSCRIBES, it does not poll
 

--- a/docs/development/REMAINING_APK_GAPS.md
+++ b/docs/development/REMAINING_APK_GAPS.md
@@ -1,0 +1,93 @@
+# Remaining APK 3.15.0 HA-shaped gaps
+
+Product catalog of Rivian Android app 3.15.0 features this Home Assistant
+integration does not expose. A row is an **HA-shaped** analogue (an HA entity
+or service that could exist). Completeness is linted by
+`tests/test_apk_transcription.py::TestRemainingApkGaps`.
+
+Probe evidence (live accepts, rejections, envelopes) stays in
+[`COMMAND_COVERAGE.md`](COMMAND_COVERAGE.md). This file owns dispositions.
+
+The APK is a lower bound: HA extras the app does not name are not APK gaps.
+
+## Candidate-to-build
+
+HA-shaped, APK has a cloud path, not in the named non-goals, no recorded VAS
+`CONFLICT` / Parallax ISE. Gateway-accepted unwired VASCommands. Do **not**
+implement these in the catalog change; live writes need owner OK.
+
+| Gap | APK evidence | HA today | Proposed analogue |
+|-----|--------------|----------|-------------------|
+| Flash lights | `FLASH_EXTERNAL_LIGHTS` VASCommand; gateway accepted on this R1T (in-flight at 9.6s, no CONFLICT). [`COMMAND_COVERAGE.md:233-276`](COMMAND_COVERAGE.md) | none | `button` |
+| Honk / external sound | `ACTIVATE_EXTERNAL_SOUND` VASCommand; gateway accepted, vehicle later `412`. Same section. | none | `button` |
+
+## Listed-not-built (named non-goals)
+
+Implementation non-goals from the remaining-features interview, or scoped out by
+the story that shipped the neighbouring surface. Listed so they are not omitted;
+not scheduled for implementation.
+
+| Gap | APK evidence | Why listed-not-built |
+|-----|--------------|----------------------|
+| Interior camera feed | `INTERIOR_CAMERA`. A *picker option* only (`gear_guard.py:37-38`), never a gate source — `camera.gear_guard_live` gates on `LIVE_CAM`/`MOTION_CAM` (`gear_guard.py:24`), so a vehicle whose only camera flag is `INTERIOR_CAMERA` gets no camera entity. | s28 scoped it out (`tests/test_camera.py::test_no_interior_entity_even_with_interior_flag`); an interior-only vehicle gets nothing (`::test_not_created_without_camera_flags`). This R1T does not advertise the flag (`CAPABILITY_MATRIX.md:83`), so it cannot be probed on the available hardware. |
+| Combined honk+flash | `HONK_AND_FLASH_LIGHTS` — **not** a VASCommand; live REJECTED twice | Button reverted; not a cloud path |
+| Trip planner / active trip / add-stop / trailers / satmap | `ACTIVE_TRIP`, `V_TRIP`, `TRIP_ADD_STOP`, `TRIP_PLANNER_TRAILERS`, `V_SATMAP` | Round 4 non-goal. Navigation `notify` already exists. |
+| Phone-key management UI | `KEY_PAAK`, `KEY_FOB_2`, `PIN_PROFILE`, `ORPHANED_PHONE_KEY_RECOVERY_HANDLING` | Pair button + counts only; Round 4 non-goal |
+
+## Listed-not-built until a live accept
+
+VAS-rejected / envelope-unknown commands, ISE Parallax writes, and unproven
+GraphQL names. A live accept (command or name-probe) is what promotes a row,
+not a decompile.
+
+Invalid-wrapper seven (`tests/test_apk_transcription.py:406-412`):
+
+| Gap | APK evidence | Blocker |
+|-----|--------------|---------|
+| Pet comfort off | `PET_COMFORT_OFF`; invalid-wrapper; VAS REJECTED | Parallax envelope NOT DERIVABLE ([`PARALLAX_SEND_PATH.md`](PARALLAX_SEND_PATH.md)). Pet *state* sensors already exist. |
+| Pet comfort on | `PET_COMFORT_ON`; invalid-wrapper; VAS REJECTED | Same |
+| Gear Guard video download | `START_VIDEO_DOWNLOADING_SESSION`; invalid-wrapper; VAS REJECTED | Same family |
+| Two-factor drive allow | `TWO_FACTOR_DRIVE_ALLOW`; VAS REJECTED | No readable state surface |
+| Two-factor drive deny | `TWO_FACTOR_DRIVE_DENY`; VAS REJECTED | Same |
+| Two-factor drive disable | `TWO_FACTOR_DRIVE_DISABLE`; VAS REJECTED | Same |
+| Two-factor drive enable | `TWO_FACTOR_DRIVE_ENABLE`; VAS REJECTED | Same |
+| Gear Guard lock enable | `ENABLE_GEAR_GUARD`; live 2026-08-26 **REJECTED** `CONFLICT/VEHICLE_COMMAND_ERROR` (no command id). `rivian_client/const.py:313-316`. Video pair stays wired (`switch.py:51-58`). | Same class as `PET_COMFORT_ON` / `HONK_AND_FLASH_LIGHTS`. HMAC was working: climate-hold VAS returned command ids on the same session. Principle -1: CONFLICT is not a capability failure. |
+| Gear Guard lock disable | `DISABLE_GEAR_GUARD`; same CONFLICT, twice (before and after ENABLE). | Same |
+| Halloween 2025 | `HLWN_25` | `sendVehicleOperation` ISE; entities removed 1.6.0 |
+| Cabin vent / auto-vent | `AUTO_VENT`, `CLM_HOLD_AUTO_VENT`; RVM `cabin_ventilation_setting` undecoded | ISE both directions; entities removed |
+| Favorite geofences | RVM `favoriteGeofences` undecoded; `rivian.set_geofences` existed | ISE; service removed. HA-shaped (service) so it stays in the catalog. |
+| Passive-entry settings | `PASSIVE_ENTRY_PROTO_V2` | ISE; entities removed |
+| Rear window status | `rearWindowStatus` (`.apk/3.15.0/jadx/sources/com/rivian/android/consumer/data/model/VehicleState2.java:60`) | Not in the five Apollo vehicleState documents. No VASCommand (no cover). Name-probe required. |
+| Charger damaged | `vehicleChargerDamaged` (`VehicleState2.java:62`) | Unproven GraphQL name. |
+| Driver occupancy | `driverOccupancyStatus` (`.apk/3.15.0/jadx/sources/com/rivian/android/consumer/data/model/VehicleState.java:39`) | Unproven GraphQL name. Occupancy *is* HA-shaped (`binary_sensor`). |
+| 2FA challenge surface | `driveAuthorizationUserInputRequestStatus` (`VehicleState2.java:38`) | Unproven GraphQL name. |
+| AC charging disabled | `chargingDisabledAC` (`rivian_client/schemas/gateway.graphql:677`) | Schema-declared sibling of subscribed `chargingDisabledACFaultState`. Not in `VEHICLE_STATE_API_FIELDS`. Name-probe required before adding to the live document. |
+
+## Already at parity via other transport
+
+Sendable VASCommands whose HA analogue already exists via another transport.
+Lint home so `SENDABLE_COMMANDS` completeness has no hole. Not remaining gaps.
+
+| Command | HA analogue | Why unused VAS |
+|---------|-------------|----------------|
+| `CLIMATE_HOLD_ON` | Cabin climate hold switch (`switch.py:69-93`); `tests/test_climate_hold_wiring.py:10-12` | VAS is gateway-accepted (2026-08-26) then vehicle `responseCode` 417; hold stayed off. Working write is Parallax. The comment at `switch.py:72` must not count as wiring. |
+| `CLIMATE_HOLD_OFF` | Same switch | Same: gateway-accepted, `417`, hold stayed off. |
+
+## Out of catalog
+
+Not HA-shaped, HA extras the APK does not name, already wired, or out of this
+story. Inclusive OR: a wired sendable may also appear here (`OPEN_LIFTGATE`,
+`OPEN_TAILGATE` in `button.py:86` and `button.py:103`).
+
+| Item | Why out |
+|------|---------|
+| Shop, account, Stripe, MapLibre, charging-network signup | Not HA-shaped (Round 5) |
+| Energy graphs / cold-weather bar charts | Not an entity/service; sensors for SoC already exist |
+| Per-door unlock / `UNLOCK_ALL_AND_OPEN_WINDOWS` | HA extras **absent from APK 3.15.0** — not an APK gap (lower bound) |
+| `OPEN_LIFTGATE` / `OPEN_TAILGATE` | Already wired, disabled by default. Tailgate actuation owner-prohibited (garage). |
+| `START_GEAR_GUARD_MASTER_SESSION` | Already wired by s28 as `camera.gear_guard_live` (`camera.py:388`). No stop VASCommand exists; tear-down is local. Clip download (`START_VIDEO_DOWNLOADING_SESSION`) is a different path and stays unwired. |
+| Unpopulated `tirePressureStatusValid*` / `cabinHoldNotification` | Not missing; subscribed and empty. Stay. |
+| s26 optional-hardware gating | Separate story; not a missing feature |
+| Gen2 BLE pairing | Separate spec; no hardware |
+| Pause-frunk / pause-liftgate / pause-tonneau | `cloudData=null` — not cloud commands |
+| Wallbox controls | Wallbox is 7 sensors; no APK VASCommand evidence gathered this interview — do not invent a row |

--- a/tests/test_apk_transcription.py
+++ b/tests/test_apk_transcription.py
@@ -847,3 +847,210 @@ class TestParallaxEnvelopeDerivation:
             PARALLAX_ATTRIBUTES_NAME_ACCESSOR_3150
             != PARALLAX_ATTRIBUTES_NAME_ACCESSOR_360_CONTEXT
         )
+
+
+_PLATFORM_MODULES: tuple[str, ...] = (
+    "button.py",
+    "camera.py",
+    "switch.py",
+    "cover.py",
+    "lock.py",
+    "climate.py",
+    "select.py",
+    "number.py",
+    "update.py",
+)
+
+_GAPS_HEADINGS: tuple[str, ...] = (
+    "Candidate-to-build",
+    "Listed-not-built (named non-goals)",
+    "Listed-not-built until a live accept",
+    "Already at parity via other transport",
+    "Out of catalog",
+)
+
+_GAP_HEADINGS: tuple[str, ...] = _GAPS_HEADINGS[:3]
+
+_UNPROVEN_GRAPHQL_NAMES: tuple[str, ...] = (
+    "rearWindowStatus",
+    "vehicleChargerDamaged",
+    "driverOccupancyStatus",
+    "driveAuthorizationUserInputRequestStatus",
+    "chargingDisabledAC",
+)
+
+
+def _strip_hash_comments(src: str) -> str:
+    """Drop `#` comments per line. Required: `\\b` matches CLIMATE_HOLD_ON in switch.py:72."""
+    return "\n".join(re.sub(r"#.*", "", line) for line in src.splitlines())
+
+
+def _platform_sources() -> str:
+    return "".join(
+        _strip_hash_comments((REPO / "custom_components/rivian" / name).read_text())
+        for name in _PLATFORM_MODULES
+    )
+
+
+def _is_wired(name: str, sources: str) -> bool:
+    return re.search(rf"VehicleCommand\.{re.escape(name)}\b", sources) is not None
+
+
+def _gaps_sections() -> dict[str, str]:
+    text = (REPO / "docs/development/REMAINING_APK_GAPS.md").read_text()
+    parts = re.split(r"^## ", text, flags=re.MULTILINE)
+    sections: dict[str, str] = {}
+    for part in parts[1:]:
+        title, _, body = part.partition("\n")
+        title = title.strip()
+        if title in _GAPS_HEADINGS:
+            sections[title] = body
+    return sections
+
+
+def _backticks(section: str) -> set[str]:
+    return set(re.findall(r"`([^`]+)`", section))
+
+
+class TestRemainingApkGaps:
+    """HA-shaped remaining-gap catalog. docs/development/REMAINING_APK_GAPS.md.
+
+    Wiring is word-boundary VehicleCommand.{NAME} over nine platform modules
+    with `#` comments stripped. Disposition tags are exact ATX `##` titles.
+    """
+
+    def test_the_five_headings_exist(self) -> None:
+        assert set(_gaps_sections()) == set(_GAPS_HEADINGS)
+
+    def test_platform_module_list_has_not_drifted(self) -> None:
+        """_PLATFORM_MODULES is hand-maintained; s28 added camera.py and missed it.
+
+        Every module that names a VehicleCommand must be in the list, or
+        _is_wired() silently answers False and the whole catalog reasons from a
+        stale premise. coordinator.py is the one deliberate exclusion: its only
+        refs are two WAKE_VEHICLE sends (coordinator.py:1956,1966), which back no
+        entity of their own.
+        """
+        naming = {
+            path.name
+            for path in (REPO / "custom_components/rivian").glob("*.py")
+            if "VehicleCommand." in path.read_text()
+        }
+        assert naming - {"coordinator.py"} == set(_PLATFORM_MODULES)
+
+    def test_there_is_no_second_test_module(self) -> None:
+        assert not (REPO / "tests/test_remaining_apk_gaps.py").exists()
+
+    def test_coverage_doc_points_at_the_catalog(self) -> None:
+        text = (REPO / "docs/development/COMMAND_COVERAGE.md").read_text()
+        assert "REMAINING_APK_GAPS.md" in text
+
+    def test_gear_guard_lock_is_not_wired_because_video_is(self) -> None:
+        """`ENABLE_GEAR_GUARD\\b` must not match ENABLE_GEAR_GUARD_VIDEO."""
+        switch = _strip_hash_comments(
+            (REPO / "custom_components/rivian/switch.py").read_text()
+        )
+        assert re.search(r"VehicleCommand\.ENABLE_GEAR_GUARD_VIDEO\b", switch)
+        assert re.search(r"VehicleCommand\.DISABLE_GEAR_GUARD_VIDEO\b", switch)
+        assert not re.search(r"VehicleCommand\.ENABLE_GEAR_GUARD\b", switch)
+        assert not re.search(r"VehicleCommand\.DISABLE_GEAR_GUARD\b", switch)
+        # The catalog claims the lock pair is unwired *anywhere*, not just here.
+        sources = _platform_sources()
+        assert not _is_wired("ENABLE_GEAR_GUARD", sources)
+        assert not _is_wired("DISABLE_GEAR_GUARD", sources)
+
+    def test_climate_hold_comment_is_not_wiring(self) -> None:
+        raw = (REPO / "custom_components/rivian/switch.py").read_text()
+        stripped = _strip_hash_comments(raw)
+        assert re.search(r"VehicleCommand\.CLIMATE_HOLD_ON\b", raw)
+        assert not re.search(r"VehicleCommand\.CLIMATE_HOLD_ON\b", stripped)
+        assert not _is_wired("CLIMATE_HOLD_ON", stripped)
+        assert not _is_wired("CLIMATE_HOLD_OFF", stripped)
+
+    def test_sendable_commands_are_wired_or_catalogued(self) -> None:
+        sources = _platform_sources()
+        sections = _gaps_sections()
+        tokens_by_heading = {
+            heading: _backticks(body) for heading, body in sections.items()
+        }
+        wired = {name for name in SENDABLE_COMMANDS if _is_wired(name, sources)}
+        candidate = tokens_by_heading["Candidate-to-build"]
+        assert not (candidate & SENDABLE_COMMANDS & wired)
+
+        for name in sorted(SENDABLE_COMMANDS):
+            homes = [
+                heading
+                for heading, tokens in tokens_by_heading.items()
+                if name in tokens
+            ]
+            assert _is_wired(name, sources) or homes, (
+                f"{name} is sendable, not wired, and not backtick-named in the catalog"
+            )
+            if not _is_wired(name, sources):
+                assert len(homes) == 1, f"{name} unwired with catalog homes {homes}"
+
+        gap_tokens: set[str] = set()
+        for heading in _GAP_HEADINGS:
+            gap_tokens |= tokens_by_heading[heading]
+        # A wired command is not a gap. s28 wired START_GEAR_GUARD_MASTER_SESSION
+        # while it sat in "named non-goals" and nothing failed: the ban above
+        # covers only Candidate-to-build, and the uniqueness check skips wired
+        # names entirely. Ban wired sendables from all three gap sections so the
+        # next s28 breaks a test instead of a claim.
+        for name in sorted(gap_tokens & SENDABLE_COMMANDS & wired):
+            homes = [h for h in _GAP_HEADINGS if name in tokens_by_heading[h]]
+            raise AssertionError(f"{name} is wired but still catalogued in {homes}")
+        assert "ENABLE_GEAR_GUARD_VIDEO" not in gap_tokens
+        assert "DISABLE_GEAR_GUARD_VIDEO" not in gap_tokens
+
+    def test_candidate_to_build_pins(self) -> None:
+        sources = _platform_sources()
+        candidate = _backticks(_gaps_sections()["Candidate-to-build"])
+        for name in (
+            "FLASH_EXTERNAL_LIGHTS",
+            "ACTIVATE_EXTERNAL_SOUND",
+        ):
+            assert name in candidate, name
+            assert not _is_wired(name, sources), name
+        assert "ENABLE_GEAR_GUARD" not in candidate
+        assert "DISABLE_GEAR_GUARD" not in candidate
+
+    def test_named_non_goal_pins(self) -> None:
+        tokens = _backticks(_gaps_sections()["Listed-not-built (named non-goals)"])
+        assert "HONK_AND_FLASH_LIGHTS" in tokens
+        # INTERIOR_CAMERA is the camera gap that survived s28: it is a picker
+        # option (gear_guard.py:37-38), never a gate source, so an interior-only
+        # vehicle gets no camera entity at all.
+        assert "INTERIOR_CAMERA" in tokens
+        # s28 wired this and shipped the camera platform. Neither belongs in a
+        # non-goals section again.
+        assert "START_GEAR_GUARD_MASTER_SESSION" not in tokens
+        assert "Platform.CAMERA" not in tokens
+
+    def test_invalid_wrapper_seven_and_unproven_fields(self) -> None:
+        tokens = _backticks(_gaps_sections()["Listed-not-built until a live accept"])
+        for name in sorted(INVALID_WRAPPER_COMMANDS):
+            assert name in tokens, name
+        for name in _UNPROVEN_GRAPHQL_NAMES:
+            assert name in tokens, name
+        assert "ENABLE_GEAR_GUARD" in tokens
+        assert "DISABLE_GEAR_GUARD" in tokens
+
+    def test_climate_hold_is_already_at_parity(self) -> None:
+        tokens = _backticks(_gaps_sections()["Already at parity via other transport"])
+        assert "CLIMATE_HOLD_ON" in tokens
+        assert "CLIMATE_HOLD_OFF" in tokens
+        sources = _platform_sources()
+        assert not _is_wired("CLIMATE_HOLD_ON", sources)
+        assert not _is_wired("CLIMATE_HOLD_OFF", sources)
+
+    def test_camera_platform_is_registered(self) -> None:
+        """s28 shipped it (`__init__.py:52`); the catalog says so, so pin it.
+
+        tests/test_camera.py calls async_setup_entry directly and never checks
+        PLATFORMS, so nothing else covers the registration.
+        """
+        from custom_components.rivian import PLATFORMS
+        from homeassistant.const import Platform
+
+        assert Platform.CAMERA in PLATFORMS


### PR DESCRIPTION
Adds `docs/development/REMAINING_APK_GAPS.md` — a product catalog of Rivian app
3.15.0 features with no HA analogue, each row given a disposition. Probe evidence
stays in `COMMAND_COVERAGE.md`; this file owns the verdicts. Completeness is
linted by `TestRemainingApkGaps`, so a sendable command cannot quietly go
uncatalogued.

Also records three live probe runs against this R1T on 2026-08-26: the unlock
family (all four `CONFLICT`), the cheap-candidate sweep (climate hold `417`, Gear
Guard lock `CONFLICT`), and a second `FLASH_EXTERNAL_LIGHTS` gateway accept.

## Reconciled to s28

This was written before s28 and sat uncommitted while s28 and s29 landed. s28
wired the Gear Guard live camera, which overruled two rows the draft asserted as
non-goals. Reconciled rather than merged as-was:

- `START_GEAR_GUARD_MASTER_SESSION` moves to **Out of catalog** as already wired
  (`camera.gear_guard_live`), keeping the one claim that survived verification —
  there is still no stop VASCommand.
- The camera row narrows to **`INTERIOR_CAMERA` only**. `LIVE_CAM` and
  `MOTION_CAM` are at parity via the union gate on `camera.gear_guard_live`
  (`CAPABILITY_MATRIX.md:87,89`); interior is a picker option, not a gate source,
  so an interior-only vehicle still gets no camera entity.
- The cheap-candidate probe is re-read as the negative control it actually is: it
  sent **no** `params.camera` and got state 4 / `1031`, while s28's gate run sent
  `camera=left` and got a live config. Two runs, one variable — that is what makes
  "the camera param is required" a measurement rather than an inference.
- `rivian_client/const.py`'s enum comment loses the same stale "no surface for it"
  claim (the fourth copy, and the one nobody greps for).

## Two lint holes closed

The drift above passed silently, and it should not have:

- `_PLATFORM_MODULES` omitted `camera.py`, so `_is_wired()` answered `False` for a
  command s28 had wired. A new `test_platform_module_list_has_not_drifted` now
  derives the list from the tree (allowlisting `coordinator.py`, whose only refs
  are two `WAKE_VEHICLE` sends), so the next such miss fails a test.
- The wired-vs-catalogued ban covered only `Candidate-to-build`, so a wired
  command could sit in the other two gap sections forever asserting it is not
  built. Generalized across all three.

`test_camera_platform_is_absent` is **inverted**, not deleted — `tests/test_camera.py`
calls `async_setup_entry` directly and never checks `PLATFORMS`, so nothing else
covers the registration.

## Verification

- `2219 passed` (full suite)
- `pre-commit run --all-files`: f11, ruff check, ruff format all pass
- Both new guards proven to fail on the regression they exist to catch
- Every `file:line` citation touched was checked by hand — nothing lints doc
  citations (f11's corpus is `custom_components/**/*.py` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011V1EUYktxPdCyhxJ4rwy7p