### PR TITLE
s32: sweep 54 app versions for commands and sensors the integration lacks

### DIFF
--- a/docs/development/APK_HISTORICAL_SWEEP.md
+++ b/docs/development/APK_HISTORICAL_SWEEP.md
@@ -1,9 +1,10 @@
 # APK historical sweep — the ledger
 
-What every published version of `com.rivian.android.consumer` on hand has named,
-and how that compares to what this integration exposes. Produced by
-`scripts/apk_corpus_sweep.py` over 26 decompiled dumps; gated by
-`scripts/gates/s17.sh`.
+What every version of `com.rivian.android.consumer` on hand has named, and how
+that compares to what this integration exposes. Produced by
+`scripts/apk_corpus_sweep.py` over **54 decompiled versions**; gated by
+`scripts/gates/s17.sh` and by `TestShippedLedgerIsGuarded` in
+`tests/test_apk_corpus_sweep.py`.
 
 **This file is the ledger.** The probe queue at the end is a prioritised *view*
 over it, not a second inventory. A name can be fully recorded here and correctly
@@ -13,114 +14,138 @@ never be probed.
 
 A decompile enumerates; only the vehicle promotes. Nothing here is evidence that
 a command works — `REMAINING_APK_GAPS.md` keeps that rule and this file inherits
-it. Equally, absence here is not evidence a command is invalid: **the app is a
-lower bound, never the schema.**
+it. Equally, absence here is not evidence a name is invalid: **the app is a lower
+bound, never the schema.**
 
-## Provenance and its limit
+## Provenance, and why cohorts matter
 
-26 dumps, versions 1.0.3 → 2.6.0 plus 3.15.0 build 4804. Three root layouts, and
-version does not predict layout: `sources/` covers all 1.x *and* `rivian_2.0.0_beta`
-(19 dumps), `java_src/` covers 2.2.0 onward (6), `jadx/sources/` the 3.15.0 tree.
+54 versions, 1.0.3 through 3.16.0. Three root layouts, and version does not
+predict layout:
 
-Counts compare **only within a cohort**. Which decompiler wrote each 1.x/2.x dump
-was never recorded, so a count that drops between versions cannot be attributed to
-a real app change rather than a lossier extraction. Only cohort C has documented
-provenance (jadx, per `docs/development/apk/REGENERATION.md`).
+| cohort | layout | versions | decompiler |
+|---|---|---|---|
+| A | `sources/` | 19 — all 1.x plus `rivian_2.0.0_beta` | **unrecorded** |
+| B | `java_src/` | 6 — 2.2.0 through 2.6.0 | **unrecorded** |
+| C | `jadx/sources/` | 29 — 2.6.1 through 3.16.0 | jadx 1.5.6, documented |
 
-| cohort | dumps | decompiler |
-|---|---|---|
-| A/sources | 1.0.3 – 1.15.0, 2.0.0_beta | unrecorded |
-| B/java_src | 2.2.0 – 2.6.0 | unrecorded |
-| C/jadx | 3.15.0 build 4804 | jadx, documented |
+Counts compare **only within a cohort**. Which decompiler wrote each A/B tree was
+never recorded, so a count that moves between them cannot be attributed to a real
+app change rather than a lossier extraction. Cohort C was decompiled here from
+APKMirror bundles with one tool version, so its counts *are* comparable to each
+other, and 3.15.0 remains its known ground truth (5 documents).
 
-## The headline: the corpus refutes claims 3.15.0 alone supports
+### The Apollo document count is non-monotonic
+
+Measured with one metric (`grep -rl --include='*.java' 'vehicleState(id:'`):
+
+| versions | documents |
+|---|---|
+| 1.0.3 – 1.4.1 | 0 |
+| 1.5.1 – 1.10.0 | 2 |
+| 1.11.0 – 2.0.0_beta | 3 |
+| 2.2.0 – 2.5.1 | **2** (a decrease) |
+| 2.6.0 – 2.6.1 | 3 |
+| 2.7.0 – 2.10.1 | **4** |
+| 2.19.1 – 3.10.0 | **3** (a decrease) |
+| 3.11.0 – 3.16.0 | 5 |
+
+Two corrections are recorded rather than silently applied. An earlier revision
+reported 1.15.0 → 4 and rested the non-monotonic claim on it; that count was
+wrong (the fourth match was `resources/classes2.dex`, a binary, admitted by an
+unfiltered grep). A later revision over-corrected and declared the corpus
+non-decreasing from a subsequence. Both were wrong: the corpus rises *and* falls
+repeatedly. The cohort rule does not depend on which way it runs — it rests on
+attribution, and the real decreases strengthen it.
+
+## The headline: the corpus keeps refuting single-build claims
 
 `REGENERATION.md` records fifteen `vehicleState` fields we subscribe to that
 appear in **zero** of 3.15.0's 32,941 files, measured by whole-word grep over
 every file. This sweep measures something narrower — depth-1 names in the
-compiled `vehicleState` documents — so the two are *not* the same metric. They
-coincide at 15 for 3.15.0, which is what makes the comparison below meaningful:
-holding this sweep's metric fixed and widening only the corpus, the residue
-collapses to **two**.
+compiled documents — so the two are *not* the same metric. They coincide at 15
+for 3.15.0, which is what makes the comparison meaningful: holding this sweep's
+metric fixed and widening only the corpus,
 
 | measured against | fields we subscribe to that the app never names |
 |---|---|
 | 3.15.0 alone | 15 |
-| all 26 versions | **2** — `batteryCapacity`, `cabinHoldNotification` |
+| 26 versions | 2 |
+| **all 54 versions** | **1 — `batteryCapacity`** |
 
-Thirteen of the fifteen *do* appear in earlier builds' documents. So does
-`cloudConnection`, which 3.15.0 also does not name. Those claims are true of
-3.15.0 and false of the app's history — which is the one question a single-build
-extraction cannot answer, and the reason this corpus was worth assembling.
+`cabinHoldNotification` turns up in an intermediate build, which fits the
+`CABIN_HOLD_*` naming era dated below. A claim that looked solid at one build,
+and still looked solid at 26, is down to a single field at 54.
 
 ## Commands — the ledger
 
-68 distinct command names. Transport is the union across every version that
+70 distinct command names. Transport is the union across every version that
 named the command.
 
 | command | versions | n | cohorts | transport |
 |---|---|---|---|---|
-| `ACTIVATE_EXTERNAL_SOUND` | 3.15.0 | 1 | C | cloud |
-| `CABIN_HVAC_3RD_ROW_REAR_LEFT_SEAT_HEAT` | 3.15.0 | 1 | C | cloud |
-| `CABIN_HVAC_3RD_ROW_REAR_RIGHT_SEAT_HEAT` | 3.15.0 | 1 | C | cloud |
-| `CABIN_HVAC_DEFROST_DEFOG` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
-| `CABIN_HVAC_LEFT_SEAT_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
-| `CABIN_HVAC_LEFT_SEAT_VENT` | 1.10.0–3.15.0 | 14 | A, B, C | cloud |
-| `CABIN_HVAC_REAR_LEFT_SEAT_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
-| `CABIN_HVAC_REAR_RIGHT_SEAT_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
-| `CABIN_HVAC_RIGHT_SEAT_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
-| `CABIN_HVAC_RIGHT_SEAT_VENT` | 1.10.0–3.15.0 | 14 | A, B, C | cloud |
-| `CABIN_HVAC_STEERING_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
-| `CABIN_PRECONDITIONING_SET_TEMP` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `CHARGING_LIMITS` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
-| `CLIMATE_HOLD_OFF` | 3.15.0 | 1 | C | cloud |
-| `CLIMATE_HOLD_ON` | 3.15.0 | 1 | C | cloud |
-| `CLOSE_ALL_WINDOWS` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `CLOSE_CHARGE_PORT_DOOR` | 3.15.0 | 1 | C | cloud |
-| `CLOSE_FRUNK` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `CLOSE_LIFTGATE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `CLOSE_TONNEAU_COVER` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `DISABLE_GEAR_GUARD` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `DISABLE_GEAR_GUARD_VIDEO` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
-| `ENABLE_GEAR_GUARD` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `ENABLE_GEAR_GUARD_VIDEO` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
-| `FLASH_EXTERNAL_LIGHTS` | 3.15.0 | 1 | C | cloud |
-| `HONK_AND_FLASH_LIGHTS` | 1.0.3–2.6.0 | 25 | A, B | cloud+ble |
-| `INVALID_COMMAND` **(not in enum)** | 1.5.1–3.15.0 | 20 | A, B, C | cloud |
-| `LOCK_ALL_CLOSURES_FEEDBACK` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `OPEN_ALL_WINDOWS` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `OPEN_CHARGE_PORT_DOOR` | 3.15.0 | 1 | C | cloud |
-| `OPEN_FRUNK` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `OPEN_LIFTGATE` | 3.15.0 | 1 | C | cloud |
-| `OPEN_LIFTGATE_UNLATCH_TAILGATE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `OPEN_TAILGATE` | 3.15.0 | 1 | C | cloud |
-| `OPEN_TONNEAU_COVER` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `OTA_INSTALL_NOW_ACKNOWLEDGE` | 1.2.1–3.15.0 | 25 | A, B, C | cloud+ble |
-| `PANIC_OFF` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `PANIC_ON` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `PAUSE_FRUNK` **(not in enum)** | 1.0.3–2.6.0 | 25 | A, B | ble-only |
-| `PAUSE_LIFTGATE` **(not in enum)** | 1.0.3–2.6.0 | 25 | A, B | ble-only |
-| `PAUSE_TONNEAU_COVER` **(not in enum)** | 1.0.3–2.6.0 | 25 | A, B | ble-only |
-| `PET_COMFORT_OFF` | 3.15.0 | 1 | C | invalid-wrapper |
-| `PET_COMFORT_ON` | 3.15.0 | 1 | C | invalid-wrapper |
-| `RELEASE_LEFT_SIDE_BIN` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `RELEASE_RIGHT_SIDE_BIN` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `START_CHARGING` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
-| `START_GEAR_GUARD_MASTER_SESSION` | 3.15.0 | 1 | C | cloud |
-| `START_VIDEO_DOWNLOADING_SESSION` | 3.15.0 | 1 | C | invalid-wrapper |
-| `STOP_CHARGING` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
-| `TWO_FACTOR_DRIVE_ALLOW` | 3.15.0 | 1 | C | invalid-wrapper |
-| `TWO_FACTOR_DRIVE_DENY` | 3.15.0 | 1 | C | invalid-wrapper |
-| `TWO_FACTOR_DRIVE_DISABLE` | 3.15.0 | 1 | C | invalid-wrapper |
-| `TWO_FACTOR_DRIVE_ENABLE` | 3.15.0 | 1 | C | invalid-wrapper |
-| `UNLOCK_ALL_AND_OPEN_WINDOWS` | 1.5.1–2.6.0 | 19 | A, B | cloud+ble |
-| `UNLOCK_ALL_CLOSURES` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `UNLOCK_DRIVER_DOOR` | 1.5.1–2.6.0 | 19 | A, B | cloud+ble |
-| `UNLOCK_PASSENGER_DOOR` | 1.5.1–2.6.0 | 19 | A, B | cloud+ble |
-| `UNLOCK_USER_PREFERENCES_AND_DISABLE_ALARM` | 1.0.3–2.6.0 | 25 | A, B | cloud+ble |
-| `VEHICLE_CABIN_PRECONDITION_DISABLE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `VEHICLE_CABIN_PRECONDITION_ENABLE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
-| `WAKE_VEHICLE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud |
+| `ACTIVATE_EXTERNAL_SOUND` | 2.19.1–3.16.0 | 24 | C | cloud |
+| `CABIN_HOLD_OFF` **(not in enum)** | 3.3.0 | 1 | C | cloud |
+| `CABIN_HOLD_ON` **(not in enum)** | 3.3.0 | 1 | C | cloud |
+| `CABIN_HVAC_3RD_ROW_REAR_LEFT_SEAT_HEAT` | 2.10.0–3.16.0 | 26 | C | cloud |
+| `CABIN_HVAC_3RD_ROW_REAR_RIGHT_SEAT_HEAT` | 2.10.0–3.16.0 | 26 | C | cloud |
+| `CABIN_HVAC_DEFROST_DEFOG` | 1.9.0–3.16.0 | 43 | A, B, C | cloud |
+| `CABIN_HVAC_LEFT_SEAT_HEAT` | 1.9.0–3.16.0 | 43 | A, B, C | cloud |
+| `CABIN_HVAC_LEFT_SEAT_VENT` | 1.10.0–3.16.0 | 42 | A, B, C | cloud |
+| `CABIN_HVAC_REAR_LEFT_SEAT_HEAT` | 1.9.0–3.16.0 | 43 | A, B, C | cloud |
+| `CABIN_HVAC_REAR_RIGHT_SEAT_HEAT` | 1.9.0–3.16.0 | 43 | A, B, C | cloud |
+| `CABIN_HVAC_RIGHT_SEAT_HEAT` | 1.9.0–3.16.0 | 43 | A, B, C | cloud |
+| `CABIN_HVAC_RIGHT_SEAT_VENT` | 1.10.0–3.16.0 | 42 | A, B, C | cloud |
+| `CABIN_HVAC_STEERING_HEAT` | 1.9.0–3.16.0 | 43 | A, B, C | cloud |
+| `CABIN_PRECONDITIONING_SET_TEMP` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `CHARGING_LIMITS` | 1.8.0–3.16.0 | 44 | A, B, C | cloud |
+| `CLIMATE_HOLD_OFF` | 3.4.0–3.16.0 | 17 | C | cloud |
+| `CLIMATE_HOLD_ON` | 3.4.0–3.16.0 | 17 | C | cloud |
+| `CLOSE_ALL_WINDOWS` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `CLOSE_CHARGE_PORT_DOOR` | 2.19.1–3.16.0 | 24 | C | cloud |
+| `CLOSE_FRUNK` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `CLOSE_LIFTGATE` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `CLOSE_TONNEAU_COVER` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `DISABLE_GEAR_GUARD` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `DISABLE_GEAR_GUARD_VIDEO` | 1.8.0–3.16.0 | 44 | A, B, C | cloud |
+| `ENABLE_GEAR_GUARD` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `ENABLE_GEAR_GUARD_VIDEO` | 1.8.0–3.16.0 | 44 | A, B, C | cloud |
+| `FLASH_EXTERNAL_LIGHTS` | 2.19.1–3.16.0 | 24 | C | cloud |
+| `HONK_AND_FLASH_LIGHTS` | 1.0.3–3.4.0 | 38 | A, B, C | cloud+ble |
+| `INVALID_COMMAND` **(not in enum)** | 1.5.1–3.16.0 | 48 | A, B, C | cloud |
+| `LOCK_ALL_CLOSURES_FEEDBACK` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `OPEN_ALL_WINDOWS` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `OPEN_CHARGE_PORT_DOOR` | 2.19.1–3.16.0 | 24 | C | cloud |
+| `OPEN_FRUNK` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `OPEN_LIFTGATE` | 2.10.0–3.16.0 | 26 | C | cloud |
+| `OPEN_LIFTGATE_UNLATCH_TAILGATE` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `OPEN_TAILGATE` | 2.10.0–3.16.0 | 26 | C | cloud |
+| `OPEN_TONNEAU_COVER` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `OTA_INSTALL_NOW_ACKNOWLEDGE` | 1.2.1–3.16.0 | 53 | A, B, C | cloud+ble |
+| `PANIC_OFF` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `PANIC_ON` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `PAUSE_FRUNK` **(not in enum)** | 1.0.3–2.6.1 | 26 | A, B, C | ble-only |
+| `PAUSE_LIFTGATE` **(not in enum)** | 1.0.3–2.6.1 | 26 | A, B, C | ble-only |
+| `PAUSE_TONNEAU_COVER` **(not in enum)** | 1.0.3–2.6.1 | 26 | A, B, C | ble-only |
+| `PET_COMFORT_OFF` | 3.14.0–3.16.0 | 3 | C | invalid-wrapper |
+| `PET_COMFORT_ON` | 3.14.0–3.16.0 | 3 | C | invalid-wrapper |
+| `RELEASE_LEFT_SIDE_BIN` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `RELEASE_RIGHT_SIDE_BIN` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `START_CHARGING` | 1.8.0–3.16.0 | 44 | A, B, C | cloud |
+| `START_GEAR_GUARD_MASTER_SESSION` | 2.10.0–3.16.0 | 26 | C | cloud |
+| `START_VIDEO_DOWNLOADING_SESSION` | 3.6.0–3.16.0 | 14 | C | invalid-wrapper |
+| `STOP_CHARGING` | 1.8.0–3.16.0 | 44 | A, B, C | cloud |
+| `TWO_FACTOR_DRIVE_ALLOW` | 3.1.0–3.16.0 | 20 | C | invalid-wrapper |
+| `TWO_FACTOR_DRIVE_DENY` | 3.1.0–3.16.0 | 20 | C | invalid-wrapper |
+| `TWO_FACTOR_DRIVE_DISABLE` | 3.7.0–3.16.0 | 12 | C | invalid-wrapper |
+| `TWO_FACTOR_DRIVE_ENABLE` | 3.7.0–3.16.0 | 12 | C | invalid-wrapper |
+| `UNLOCK_ALL_AND_OPEN_WINDOWS` | 1.5.1–3.4.0 | 32 | A, B, C | cloud+ble |
+| `UNLOCK_ALL_CLOSURES` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `UNLOCK_DRIVER_DOOR` | 1.5.1–3.4.0 | 32 | A, B, C | cloud+ble |
+| `UNLOCK_PASSENGER_DOOR` | 1.5.1–3.4.0 | 32 | A, B, C | cloud+ble |
+| `UNLOCK_USER_PREFERENCES_AND_DISABLE_ALARM` | 1.0.3–3.4.0 | 38 | A, B, C | cloud+ble |
+| `VEHICLE_CABIN_PRECONDITION_DISABLE` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `VEHICLE_CABIN_PRECONDITION_ENABLE` | 1.0.3–3.16.0 | 54 | A, B, C | cloud+ble |
+| `WAKE_VEHICLE` | 1.0.3–3.16.0 | 54 | A, B, C | cloud |
 | `WINCH_ACCEPT_CONTROLLER_ROLE` **(not in enum)** | 1.3.0–1.4.1 | 4 | A | ble-only |
 | `WINCH_CANCEL` **(not in enum)** | 1.0.3–1.4.1 | 6 | A | ble-only |
 | `WINCH_FREE_SPOOL` **(not in enum)** | 1.0.3–1.4.1 | 6 | A | ble-only |
@@ -129,41 +154,50 @@ named the command.
 | `WINCH_REENGAGE` **(not in enum)** | 1.3.0–1.4.1 | 4 | A | ble-only |
 | `WINCH_REJECT_CONTROLLER_ROLE` **(not in enum)** | 1.3.0–1.4.1 | 4 | A | ble-only |
 
-## The command-side result is negative, and that is the finding
+## The command-side result is still negative
 
-The only cloud-sendable name in the app that is absent from `VehicleCommand` is
-`INVALID_COMMAND`, a sentinel class rather than a vehicle command. **Twenty-six
-versions of history yielded no new cloud-sendable command to probe.** Every other
-app-only command is BLE-only and is listed in the appendix below.
+The only cloud-sendable name absent from `VehicleCommand` is `INVALID_COMMAND`,
+a sentinel class. **Fifty-four versions yielded no new cloud-sendable command to
+probe.** Every other app-only command is BLE-only and appears in the appendix.
+
+**A rename, caught in a single build.** `CABIN_HOLD_ON` / `CABIN_HOLD_OFF` exist
+in **3.3.0 and nowhere else**; from 3.4.0 onward the app says
+`CLIMATE_HOLD_ON` / `CLIMATE_HOLD_OFF`, which is what the enum already carries.
+So these are a superseded spelling, not a missing capability — and a
+one-version transitional name is invisible to any sampling stride and to 3.15.0
+alone. It is likely also why the integration subscribes to a field named
+`cabinHoldNotification`.
 
 Two enum members appear in **no version at all**:
 `CABIN_HVAC_THIRD_ROW_LEFT_SEAT_HEAT` and `CABIN_HVAC_THIRD_ROW_RIGHT_SEAT_HEAT`.
-`rivian_client/const.py` speculated these might belong to an older app; measured
-across the full corpus, no app version has ever named them. They stay — the app
-is a lower bound.
+`rivian_client/const.py` speculated these might belong to an older app; across 54
+versions, none has ever named them. They stay — the app is a lower bound.
 
 ## Sensor surfaces
 
 | surface | app | ours | app-only | ours-only | floor |
 |---|---|---|---|---|---|
-| `vehicleState` (depth-1) | 157 | 149 | 10 | 2 | 157 |
-| Parallax RVM (3.x only) | 58 | 33 | 25 | 0 | 58 |
-| `VehicleFeature` | 89 | 64 | 25 | 0 | 89 |
+| `vehicleState` (depth-1) | 159 | 149 | 11 | 1 | 157 |
+| Parallax RVM | 80 | 33 | 47 | 0 | 58 |
+| `VehicleFeature` | 98 | 64 | 34 | 0 | 89 |
 | charging / wallbox | 52 | 72 | 2 | 22 | 52 |
 
 `vehicleState` uses the depth-1 metric of
-`scripts/gates/helpers/apk_vehicle_state_fields.py`, not a union at any depth.
-Only depth-1 names are comparable to `VEHICLE_STATE_API_FIELDS`, which is a set of
-top-level subscribed fields. Parallax draws on 3.x only: `ParallaxAttributes` is
-absent from every 2.x tree, so the historical corpus contributes nothing there.
+`scripts/gates/helpers/apk_vehicle_state_fields.py`, not a union at any depth —
+only depth-1 names are comparable to `VEHICLE_STATE_API_FIELDS`. A test pins the
+two implementations together so they cannot drift.
+
+**Parallax draws on 24 versions, from 2.19.1 onward** — not 3.x only, as an
+earlier revision of this file said. **80 RVM types against 33 decoded** is the
+largest single gap this sweep found.
 
 Each surface carries its own floor; a union below it is an error and exits 1.
-Growth is fine and reported.
 
 ### `vehicleState` fields the app names and we do not
 
 | field | seen |
 |---|---|
+| `chargingDisabledAC` | 2.7.0–2.10.1 |
 | `cloudConnection` | 1.5.1–2.0.0_beta |
 | `otaPreconditionFailActiveMode` | 1.5.1 |
 | `otaPreconditionFailFastCharging` | 1.5.1 |
@@ -171,28 +205,27 @@ Growth is fine and reported.
 | `otaPreconditionFailLVBatt` | 1.5.1 |
 | `otaPreconditionFailNotParked` | 1.5.1 |
 | `otaPreconditionFailOther` | 1.5.1 |
-| `passiveEntryUnlockFailReason` | 3.15.0 |
-| `vasAccessCanFaulted` | 3.15.0 |
-| `vasSecureElementFaulted` | 3.15.0 |
+| `passiveEntryUnlockFailReason` | 3.7.0–3.16.0 |
+| `vasAccessCanFaulted` | 3.8.0–3.16.0 |
+| `vasSecureElementFaulted` | 3.8.0–3.16.0 |
 
 ### charging / wallbox names the vendored schema does not declare
 
 | field | seen |
 |---|---|
 | `activated` | 1.0.3 |
-| `updatedAt` | 1.8.0–2.6.0 |
+| `updatedAt` | 1.8.0–2.19.1 |
 
 ## Appendix — BLE-only commands
 
 No cloud path in any version, so none is sendable by this integration, which
-sends commands via cloud after pairing. Recorded because the ledger is the union
-of what the app named, not the subset that is actionable.
+sends via cloud after pairing.
 
 | command | versions | n |
 |---|---|---|
-| `PAUSE_FRUNK` | 1.0.3–2.6.0 | 25 |
-| `PAUSE_LIFTGATE` | 1.0.3–2.6.0 | 25 |
-| `PAUSE_TONNEAU_COVER` | 1.0.3–2.6.0 | 25 |
+| `PAUSE_FRUNK` | 1.0.3–2.6.1 | 26 |
+| `PAUSE_LIFTGATE` | 1.0.3–2.6.1 | 26 |
+| `PAUSE_TONNEAU_COVER` | 1.0.3–2.6.1 | 26 |
 | `WINCH_ACCEPT_CONTROLLER_ROLE` | 1.3.0–1.4.1 | 4 |
 | `WINCH_CANCEL` | 1.0.3–1.4.1 | 6 |
 | `WINCH_FREE_SPOOL` | 1.0.3–1.4.1 | 6 |
@@ -201,37 +234,42 @@ of what the app named, not the subset that is actionable.
 | `WINCH_REENGAGE` | 1.3.0–1.4.1 | 4 |
 | `WINCH_REJECT_CONTROLLER_ROLE` | 1.3.0–1.4.1 | 4 |
 
-The winch family ran 1.0.3 – 1.4.1 and was dropped. `PAUSE_*` persisted to 2.6.0,
-corroborating `REMAINING_APK_GAPS.md`'s existing row: `cloudData=null`, not cloud
-commands.
-
 ## Probe queue — a prioritised view over the ledger
 
-Ordered by expected yield. Rows with a recorded live rejection are **held out with
-a re-entry condition**, not foreclosed: `REMAINING_APK_GAPS.md` is explicit that a
-`CONFLICT` is not a capability failure.
+Rows with a recorded live rejection are **held out with a re-entry condition**,
+not foreclosed: `REMAINING_APK_GAPS.md` is explicit that a `CONFLICT` is not a
+capability failure.
 
-| # | target | kind | expected signal | promotes on |
-|---|---|---|---|---|
-| 1 | `passiveEntryUnlockFailReason` | name-probe | subscription accepts the name | any live value |
-| 2 | `vasAccessCanFaulted` | name-probe | subscription accepts the name | any live value |
-| 3 | `vasSecureElementFaulted` | name-probe | subscription accepts the name | any live value |
-| 4 | 25 undecoded Parallax RVMs | decode | RVM frames already arriving | a decoded value |
-| 5 | `activated`, `updatedAt` (wallbox) | name-probe | schema accepts the name | any live value |
+### Probed and accepted, 2026-08-31
 
-Rows 1–3 are the strongest: they are in the **current** build, so the live gateway
-plausibly still serves them. A single unknown name is fatal to an entire
-subscription, so probe them one at a time against a scratch document, never by
-adding them to `VEHICLE_STATE_API_FIELDS` first.
+All three current-build candidates were live-ACCEPTED with real values, which is
+what promoted them in the catalog. Details in `COMMAND_COVERAGE.md`.
 
-### Held out, with re-entry conditions
+| field | result |
+|---|---|
+| `passiveEntryUnlockFailReason` | ACCEPTED, delivered `AT_HOME_DISABLE` |
+| `vasAccessCanFaulted` | ACCEPTED, delivered `no_failure` |
+| `vasSecureElementFaulted` | ACCEPTED, delivered `no_failure` |
 
-| target | why held | re-entry |
-|---|---|---|
-| `UNLOCK_ALL_AND_OPEN_WINDOWS`, `UNLOCK_DRIVER_DOOR`, `UNLOCK_PASSENGER_DOOR`, `UNLOCK_USER_PREFERENCES_AND_DISABLE_ALARM` | live-REJECTED `CONFLICT` 2026-08-26 (`COMMAND_COVERAGE.md`) | firmware change, or a materially different vehicle state |
-| `HONK_AND_FLASH_LIGHTS` | same class, REJECTED twice | same |
-| 7 winch + 3 pause commands | BLE-only in every version; no cloud path exists | a cloud wrapper appearing in a future build |
-| 6 `otaPreconditionFail*`, `cloudConnection` | app named them only historically; dropped | reappearance in a current build |
+Their value vocabularies are one sample from one R1T: `no_failure` is the healthy
+arm of a fault enum whose other arms are unobserved, so a sensor mapping only
+seen values would mis-render every unseen state.
 
-Nothing here is scheduled. A probe is an owner decision, and command sends
-actuate a real vehicle.
+### Next candidates
+
+| # | target | kind | promotes on |
+|---|---|---|---|
+| 1 | `chargingDisabledAC` | name-probe | now corpus-confirmed as a real app name; a live accept |
+| 2 | 47 undecoded Parallax RVMs | decode | a decoded value from frames already arriving |
+| 3 | `activated`, `updatedAt` (wallbox) | name-probe | a live accept |
+| 4 | 34 `VehicleFeature` members we do not gate on | inspect | evidence the server emits the `featureName` |
+
+Historical-only names (`cloudConnection`, the six `otaPreconditionFail*`) are
+recorded but not queued: the app dropped them, so a probe tests nothing current.
+
+## Corpus gaps
+
+APKMirror lists 30 versions and carries nothing older than 2.5.1. `3.2.x`,
+`2.9`, and `2.11`–`2.18` are absent from every source checked, so the ledger has
+real holes. A name first appearing at, say, 2.19.1 may have arrived any time
+after 2.10.1 — the windows above are bounds, not birthdates.

--- a/docs/development/APK_HISTORICAL_SWEEP.md
+++ b/docs/development/APK_HISTORICAL_SWEEP.md
@@ -1,0 +1,237 @@
+# APK historical sweep — the ledger
+
+What every published version of `com.rivian.android.consumer` on hand has named,
+and how that compares to what this integration exposes. Produced by
+`scripts/apk_corpus_sweep.py` over 26 decompiled dumps; gated by
+`scripts/gates/s17.sh`.
+
+**This file is the ledger.** The probe queue at the end is a prioritised *view*
+over it, not a second inventory. A name can be fully recorded here and correctly
+never be probed.
+
+## What this is not
+
+A decompile enumerates; only the vehicle promotes. Nothing here is evidence that
+a command works — `REMAINING_APK_GAPS.md` keeps that rule and this file inherits
+it. Equally, absence here is not evidence a command is invalid: **the app is a
+lower bound, never the schema.**
+
+## Provenance and its limit
+
+26 dumps, versions 1.0.3 → 2.6.0 plus 3.15.0 build 4804. Three root layouts, and
+version does not predict layout: `sources/` covers all 1.x *and* `rivian_2.0.0_beta`
+(19 dumps), `java_src/` covers 2.2.0 onward (6), `jadx/sources/` the 3.15.0 tree.
+
+Counts compare **only within a cohort**. Which decompiler wrote each 1.x/2.x dump
+was never recorded, so a count that drops between versions cannot be attributed to
+a real app change rather than a lossier extraction. Only cohort C has documented
+provenance (jadx, per `docs/development/apk/REGENERATION.md`).
+
+| cohort | dumps | decompiler |
+|---|---|---|
+| A/sources | 1.0.3 – 1.15.0, 2.0.0_beta | unrecorded |
+| B/java_src | 2.2.0 – 2.6.0 | unrecorded |
+| C/jadx | 3.15.0 build 4804 | jadx, documented |
+
+## The headline: the corpus refutes claims 3.15.0 alone supports
+
+`REGENERATION.md` records fifteen `vehicleState` fields we subscribe to that
+appear in **zero** of 3.15.0's 32,941 files, measured by whole-word grep over
+every file. This sweep measures something narrower — depth-1 names in the
+compiled `vehicleState` documents — so the two are *not* the same metric. They
+coincide at 15 for 3.15.0, which is what makes the comparison below meaningful:
+holding this sweep's metric fixed and widening only the corpus, the residue
+collapses to **two**.
+
+| measured against | fields we subscribe to that the app never names |
+|---|---|
+| 3.15.0 alone | 15 |
+| all 26 versions | **2** — `batteryCapacity`, `cabinHoldNotification` |
+
+Thirteen of the fifteen *do* appear in earlier builds' documents. So does
+`cloudConnection`, which 3.15.0 also does not name. Those claims are true of
+3.15.0 and false of the app's history — which is the one question a single-build
+extraction cannot answer, and the reason this corpus was worth assembling.
+
+## Commands — the ledger
+
+68 distinct command names. Transport is the union across every version that
+named the command.
+
+| command | versions | n | cohorts | transport |
+|---|---|---|---|---|
+| `ACTIVATE_EXTERNAL_SOUND` | 3.15.0 | 1 | C | cloud |
+| `CABIN_HVAC_3RD_ROW_REAR_LEFT_SEAT_HEAT` | 3.15.0 | 1 | C | cloud |
+| `CABIN_HVAC_3RD_ROW_REAR_RIGHT_SEAT_HEAT` | 3.15.0 | 1 | C | cloud |
+| `CABIN_HVAC_DEFROST_DEFOG` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
+| `CABIN_HVAC_LEFT_SEAT_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
+| `CABIN_HVAC_LEFT_SEAT_VENT` | 1.10.0–3.15.0 | 14 | A, B, C | cloud |
+| `CABIN_HVAC_REAR_LEFT_SEAT_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
+| `CABIN_HVAC_REAR_RIGHT_SEAT_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
+| `CABIN_HVAC_RIGHT_SEAT_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
+| `CABIN_HVAC_RIGHT_SEAT_VENT` | 1.10.0–3.15.0 | 14 | A, B, C | cloud |
+| `CABIN_HVAC_STEERING_HEAT` | 1.9.0–3.15.0 | 15 | A, B, C | cloud |
+| `CABIN_PRECONDITIONING_SET_TEMP` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `CHARGING_LIMITS` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
+| `CLIMATE_HOLD_OFF` | 3.15.0 | 1 | C | cloud |
+| `CLIMATE_HOLD_ON` | 3.15.0 | 1 | C | cloud |
+| `CLOSE_ALL_WINDOWS` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `CLOSE_CHARGE_PORT_DOOR` | 3.15.0 | 1 | C | cloud |
+| `CLOSE_FRUNK` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `CLOSE_LIFTGATE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `CLOSE_TONNEAU_COVER` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `DISABLE_GEAR_GUARD` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `DISABLE_GEAR_GUARD_VIDEO` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
+| `ENABLE_GEAR_GUARD` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `ENABLE_GEAR_GUARD_VIDEO` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
+| `FLASH_EXTERNAL_LIGHTS` | 3.15.0 | 1 | C | cloud |
+| `HONK_AND_FLASH_LIGHTS` | 1.0.3–2.6.0 | 25 | A, B | cloud+ble |
+| `INVALID_COMMAND` **(not in enum)** | 1.5.1–3.15.0 | 20 | A, B, C | cloud |
+| `LOCK_ALL_CLOSURES_FEEDBACK` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `OPEN_ALL_WINDOWS` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `OPEN_CHARGE_PORT_DOOR` | 3.15.0 | 1 | C | cloud |
+| `OPEN_FRUNK` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `OPEN_LIFTGATE` | 3.15.0 | 1 | C | cloud |
+| `OPEN_LIFTGATE_UNLATCH_TAILGATE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `OPEN_TAILGATE` | 3.15.0 | 1 | C | cloud |
+| `OPEN_TONNEAU_COVER` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `OTA_INSTALL_NOW_ACKNOWLEDGE` | 1.2.1–3.15.0 | 25 | A, B, C | cloud+ble |
+| `PANIC_OFF` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `PANIC_ON` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `PAUSE_FRUNK` **(not in enum)** | 1.0.3–2.6.0 | 25 | A, B | ble-only |
+| `PAUSE_LIFTGATE` **(not in enum)** | 1.0.3–2.6.0 | 25 | A, B | ble-only |
+| `PAUSE_TONNEAU_COVER` **(not in enum)** | 1.0.3–2.6.0 | 25 | A, B | ble-only |
+| `PET_COMFORT_OFF` | 3.15.0 | 1 | C | invalid-wrapper |
+| `PET_COMFORT_ON` | 3.15.0 | 1 | C | invalid-wrapper |
+| `RELEASE_LEFT_SIDE_BIN` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `RELEASE_RIGHT_SIDE_BIN` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `START_CHARGING` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
+| `START_GEAR_GUARD_MASTER_SESSION` | 3.15.0 | 1 | C | cloud |
+| `START_VIDEO_DOWNLOADING_SESSION` | 3.15.0 | 1 | C | invalid-wrapper |
+| `STOP_CHARGING` | 1.8.0–3.15.0 | 16 | A, B, C | cloud |
+| `TWO_FACTOR_DRIVE_ALLOW` | 3.15.0 | 1 | C | invalid-wrapper |
+| `TWO_FACTOR_DRIVE_DENY` | 3.15.0 | 1 | C | invalid-wrapper |
+| `TWO_FACTOR_DRIVE_DISABLE` | 3.15.0 | 1 | C | invalid-wrapper |
+| `TWO_FACTOR_DRIVE_ENABLE` | 3.15.0 | 1 | C | invalid-wrapper |
+| `UNLOCK_ALL_AND_OPEN_WINDOWS` | 1.5.1–2.6.0 | 19 | A, B | cloud+ble |
+| `UNLOCK_ALL_CLOSURES` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `UNLOCK_DRIVER_DOOR` | 1.5.1–2.6.0 | 19 | A, B | cloud+ble |
+| `UNLOCK_PASSENGER_DOOR` | 1.5.1–2.6.0 | 19 | A, B | cloud+ble |
+| `UNLOCK_USER_PREFERENCES_AND_DISABLE_ALARM` | 1.0.3–2.6.0 | 25 | A, B | cloud+ble |
+| `VEHICLE_CABIN_PRECONDITION_DISABLE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `VEHICLE_CABIN_PRECONDITION_ENABLE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud+ble |
+| `WAKE_VEHICLE` | 1.0.3–3.15.0 | 26 | A, B, C | cloud |
+| `WINCH_ACCEPT_CONTROLLER_ROLE` **(not in enum)** | 1.3.0–1.4.1 | 4 | A | ble-only |
+| `WINCH_CANCEL` **(not in enum)** | 1.0.3–1.4.1 | 6 | A | ble-only |
+| `WINCH_FREE_SPOOL` **(not in enum)** | 1.0.3–1.4.1 | 6 | A | ble-only |
+| `WINCH_IN` **(not in enum)** | 1.0.3–1.4.1 | 6 | A | ble-only |
+| `WINCH_OUT` **(not in enum)** | 1.0.3–1.4.1 | 6 | A | ble-only |
+| `WINCH_REENGAGE` **(not in enum)** | 1.3.0–1.4.1 | 4 | A | ble-only |
+| `WINCH_REJECT_CONTROLLER_ROLE` **(not in enum)** | 1.3.0–1.4.1 | 4 | A | ble-only |
+
+## The command-side result is negative, and that is the finding
+
+The only cloud-sendable name in the app that is absent from `VehicleCommand` is
+`INVALID_COMMAND`, a sentinel class rather than a vehicle command. **Twenty-six
+versions of history yielded no new cloud-sendable command to probe.** Every other
+app-only command is BLE-only and is listed in the appendix below.
+
+Two enum members appear in **no version at all**:
+`CABIN_HVAC_THIRD_ROW_LEFT_SEAT_HEAT` and `CABIN_HVAC_THIRD_ROW_RIGHT_SEAT_HEAT`.
+`rivian_client/const.py` speculated these might belong to an older app; measured
+across the full corpus, no app version has ever named them. They stay — the app
+is a lower bound.
+
+## Sensor surfaces
+
+| surface | app | ours | app-only | ours-only | floor |
+|---|---|---|---|---|---|
+| `vehicleState` (depth-1) | 157 | 149 | 10 | 2 | 157 |
+| Parallax RVM (3.x only) | 58 | 33 | 25 | 0 | 58 |
+| `VehicleFeature` | 89 | 64 | 25 | 0 | 89 |
+| charging / wallbox | 52 | 72 | 2 | 22 | 52 |
+
+`vehicleState` uses the depth-1 metric of
+`scripts/gates/helpers/apk_vehicle_state_fields.py`, not a union at any depth.
+Only depth-1 names are comparable to `VEHICLE_STATE_API_FIELDS`, which is a set of
+top-level subscribed fields. Parallax draws on 3.x only: `ParallaxAttributes` is
+absent from every 2.x tree, so the historical corpus contributes nothing there.
+
+Each surface carries its own floor; a union below it is an error and exits 1.
+Growth is fine and reported.
+
+### `vehicleState` fields the app names and we do not
+
+| field | seen |
+|---|---|
+| `cloudConnection` | 1.5.1–2.0.0_beta |
+| `otaPreconditionFailActiveMode` | 1.5.1 |
+| `otaPreconditionFailFastCharging` | 1.5.1 |
+| `otaPreconditionFailHVBattLow` | 1.5.1 |
+| `otaPreconditionFailLVBatt` | 1.5.1 |
+| `otaPreconditionFailNotParked` | 1.5.1 |
+| `otaPreconditionFailOther` | 1.5.1 |
+| `passiveEntryUnlockFailReason` | 3.15.0 |
+| `vasAccessCanFaulted` | 3.15.0 |
+| `vasSecureElementFaulted` | 3.15.0 |
+
+### charging / wallbox names the vendored schema does not declare
+
+| field | seen |
+|---|---|
+| `activated` | 1.0.3 |
+| `updatedAt` | 1.8.0–2.6.0 |
+
+## Appendix — BLE-only commands
+
+No cloud path in any version, so none is sendable by this integration, which
+sends commands via cloud after pairing. Recorded because the ledger is the union
+of what the app named, not the subset that is actionable.
+
+| command | versions | n |
+|---|---|---|
+| `PAUSE_FRUNK` | 1.0.3–2.6.0 | 25 |
+| `PAUSE_LIFTGATE` | 1.0.3–2.6.0 | 25 |
+| `PAUSE_TONNEAU_COVER` | 1.0.3–2.6.0 | 25 |
+| `WINCH_ACCEPT_CONTROLLER_ROLE` | 1.3.0–1.4.1 | 4 |
+| `WINCH_CANCEL` | 1.0.3–1.4.1 | 6 |
+| `WINCH_FREE_SPOOL` | 1.0.3–1.4.1 | 6 |
+| `WINCH_IN` | 1.0.3–1.4.1 | 6 |
+| `WINCH_OUT` | 1.0.3–1.4.1 | 6 |
+| `WINCH_REENGAGE` | 1.3.0–1.4.1 | 4 |
+| `WINCH_REJECT_CONTROLLER_ROLE` | 1.3.0–1.4.1 | 4 |
+
+The winch family ran 1.0.3 – 1.4.1 and was dropped. `PAUSE_*` persisted to 2.6.0,
+corroborating `REMAINING_APK_GAPS.md`'s existing row: `cloudData=null`, not cloud
+commands.
+
+## Probe queue — a prioritised view over the ledger
+
+Ordered by expected yield. Rows with a recorded live rejection are **held out with
+a re-entry condition**, not foreclosed: `REMAINING_APK_GAPS.md` is explicit that a
+`CONFLICT` is not a capability failure.
+
+| # | target | kind | expected signal | promotes on |
+|---|---|---|---|---|
+| 1 | `passiveEntryUnlockFailReason` | name-probe | subscription accepts the name | any live value |
+| 2 | `vasAccessCanFaulted` | name-probe | subscription accepts the name | any live value |
+| 3 | `vasSecureElementFaulted` | name-probe | subscription accepts the name | any live value |
+| 4 | 25 undecoded Parallax RVMs | decode | RVM frames already arriving | a decoded value |
+| 5 | `activated`, `updatedAt` (wallbox) | name-probe | schema accepts the name | any live value |
+
+Rows 1–3 are the strongest: they are in the **current** build, so the live gateway
+plausibly still serves them. A single unknown name is fatal to an entire
+subscription, so probe them one at a time against a scratch document, never by
+adding them to `VEHICLE_STATE_API_FIELDS` first.
+
+### Held out, with re-entry conditions
+
+| target | why held | re-entry |
+|---|---|---|
+| `UNLOCK_ALL_AND_OPEN_WINDOWS`, `UNLOCK_DRIVER_DOOR`, `UNLOCK_PASSENGER_DOOR`, `UNLOCK_USER_PREFERENCES_AND_DISABLE_ALARM` | live-REJECTED `CONFLICT` 2026-08-26 (`COMMAND_COVERAGE.md`) | firmware change, or a materially different vehicle state |
+| `HONK_AND_FLASH_LIGHTS` | same class, REJECTED twice | same |
+| 7 winch + 3 pause commands | BLE-only in every version; no cloud path exists | a cloud wrapper appearing in a future build |
+| 6 `otaPreconditionFail*`, `cloudConnection` | app named them only historically; dropped | reappearance in a current build |
+
+Nothing here is scheduled. A probe is an owner decision, and command sends
+actuate a real vehicle.

--- a/docs/development/COMMAND_COVERAGE.md
+++ b/docs/development/COMMAND_COVERAGE.md
@@ -351,3 +351,36 @@ poll is a redundant fallback that happens to be marginally faster. Whether to ke
 trade-off — fidelity to the app and one fewer query per command, against ~1 s of perceived latency
 and a fallback if the subscription ever regresses to the behaviour `ae06ee9` believed it had. Not
 decided here; it is a live-command-path change and belongs behind its own gate.
+
+## Name-probes, 2026-08-31 — the three s32 corpus candidates, all ACCEPTED
+
+`docs/development/APK_HISTORICAL_SWEEP.md` found three `vehicleState` names in
+3.15.0's compiled documents that `VEHICLE_STATE_API_FIELDS` does not carry. A
+decompile does not promote a row, so they were probed.
+
+`scripts/probe_field_names.py`, read-only: subscriptions only, no command sent
+and nothing actuated. Each candidate rode **alone** with the two known-good
+control fields rather than being added to the live document — the server rejects
+the entire document on one unknown name, so a shared probe cannot say which name
+killed it, and an unproven name inside `VEHICLE_STATE_API_FIELDS` would take out
+every sensor at once instead of one probe. Control ran first and was accepted, so
+the instrument was valid before any candidate was judged by it.
+
+| Field | Result | Value observed |
+|---|---|---|
+| `passiveEntryUnlockFailReason` | **ACCEPTED**, delivered (0.2 s) | `AT_HOME_DISABLE` |
+| `vasAccessCanFaulted` | **ACCEPTED**, delivered (0.4 s) | `no_failure` |
+| `vasSecureElementFaulted` | **ACCEPTED**, delivered (0.3 s) | `no_failure` |
+
+Three for three, each carrying a real value rather than an accepted silence. The
+gateway knows all three names on this account today, which is what promotes them
+in [`REMAINING_APK_GAPS.md`](REMAINING_APK_GAPS.md) from "unproven GraphQL name"
+to candidate-to-build.
+
+Two cautions before anything ships. The value vocabularies here are one sample
+from one R1T at one moment: `no_failure` is plainly the healthy arm of a fault
+enum whose other arms are unobserved, and `AT_HOME_DISABLE` is one of an unknown
+number of passive-entry reasons. Building a sensor that maps only these values
+would mis-render every state that has not been seen yet. And an accept on this
+account is not an accept on every account — `supportedFeatures` gating still
+applies, as `TONNEAU_CMD` established.

--- a/docs/development/REMAINING_APK_GAPS.md
+++ b/docs/development/REMAINING_APK_GAPS.md
@@ -19,6 +19,9 @@ implement these in the catalog change; live writes need owner OK.
 | Gap | APK evidence | HA today | Proposed analogue |
 |-----|--------------|----------|-------------------|
 | Flash lights | `FLASH_EXTERNAL_LIGHTS` VASCommand; gateway accepted on this R1T (in-flight at 9.6s, no CONFLICT). [`COMMAND_COVERAGE.md:233-276`](COMMAND_COVERAGE.md) | none | `button` |
+| Passive-entry unlock fail reason | `passiveEntryUnlockFailReason` in 3.15.0's documents ([`APK_HISTORICAL_SWEEP.md`](APK_HISTORICAL_SWEEP.md)); **live-ACCEPTED 2026-08-31**, delivered `AT_HOME_DISABLE` ([`COMMAND_COVERAGE.md`](COMMAND_COVERAGE.md)) | none | `sensor` — but the value vocabulary is one sample; other reasons are unobserved |
+| VAS access CAN faulted | `vasAccessCanFaulted`; **live-ACCEPTED 2026-08-31**, delivered `no_failure`. Same sections. | none | `binary_sensor` — `no_failure` is the healthy arm of a fault enum whose other arms are unobserved |
+| VAS secure element faulted | `vasSecureElementFaulted`; **live-ACCEPTED 2026-08-31**, delivered `no_failure`. Same sections. | none | `binary_sensor`, same caveat |
 | Honk / external sound | `ACTIVATE_EXTERNAL_SOUND` VASCommand; gateway accepted, vehicle later `412`. Same section. | none | `button` |
 
 ## Listed-not-built (named non-goals)
@@ -61,6 +64,7 @@ Invalid-wrapper seven (`tests/test_apk_transcription.py:406-412`):
 | Charger damaged | `vehicleChargerDamaged` (`VehicleState2.java:62`) | Unproven GraphQL name. |
 | Driver occupancy | `driverOccupancyStatus` (`.apk/3.15.0/jadx/sources/com/rivian/android/consumer/data/model/VehicleState.java:39`) | Unproven GraphQL name. Occupancy *is* HA-shaped (`binary_sensor`). |
 | 2FA challenge surface | `driveAuthorizationUserInputRequestStatus` (`VehicleState2.java:38`) | Unproven GraphQL name. |
+| Winch control (7 commands) | `WINCH_IN`, `WINCH_OUT`, `WINCH_CANCEL`, `WINCH_FREE_SPOOL`, `WINCH_REENGAGE`, `WINCH_ACCEPT_CONTROLLER_ROLE`, `WINCH_REJECT_CONTROLLER_ROLE` — real VASCommands in 1.0.3–1.4.1 only, then dropped. Same source. | **BLE-only in every version; no cloud wrapper ever existed**, and this integration sends via cloud after pairing. Not sendable without new BLE plumbing. Re-entry: a cloud wrapper appearing in a future build. |
 | AC charging disabled | `chargingDisabledAC` (`rivian_client/schemas/gateway.graphql:677`) | Schema-declared sibling of subscribed `chargingDisabledACFaultState`. Not in `VEHICLE_STATE_API_FIELDS`. Name-probe required before adding to the live document. |
 
 ## Already at parity via other transport
@@ -89,5 +93,6 @@ story. Inclusive OR: a wired sendable may also appear here (`OPEN_LIFTGATE`,
 | Unpopulated `tirePressureStatusValid*` / `cabinHoldNotification` | Not missing; subscribed and empty. Stay. |
 | s26 optional-hardware gating | Separate story; not a missing feature |
 | Gen2 BLE pairing | Separate spec; no hardware |
-| Pause-frunk / pause-liftgate / pause-tonneau | `cloudData=null` — not cloud commands |
+| Pause-frunk / pause-liftgate / pause-tonneau | `cloudData=null` — not cloud commands. Corroborated across the corpus (s32): `PAUSE_FRUNK`, `PAUSE_LIFTGATE`, `PAUSE_TONNEAU_COVER` are BLE-only in all 25 versions 1.0.3–2.6.0, and in 3.15.0 the three classes lost the BLE path without gaining a cloud one. [`APK_HISTORICAL_SWEEP.md`](APK_HISTORICAL_SWEEP.md) |
+| `CABIN_HVAC_THIRD_ROW_{LEFT,RIGHT}_SEAT_HEAT` | Absent from **every** app version 1.0.3–3.15.0, measured across 26 dumps (s32). `rivian_client/const.py` speculated they might belong to an older firmware or app; no app version has ever named them. They **stay** in the enum — the app is a lower bound, never the schema, and the neighbouring `CABIN_HVAC_3RD_ROW_*` spelling is the one 3.15.0 actually sends. [`APK_HISTORICAL_SWEEP.md`](APK_HISTORICAL_SWEEP.md) |
 | Wallbox controls | Wallbox is 7 sensors; no APK VASCommand evidence gathered this interview — do not invent a row |

--- a/docs/development/REMAINING_APK_GAPS.md
+++ b/docs/development/REMAINING_APK_GAPS.md
@@ -30,7 +30,7 @@ not scheduled for implementation.
 | Gap | APK evidence | Why listed-not-built |
 |-----|--------------|----------------------|
 | Interior camera feed | `INTERIOR_CAMERA`. A *picker option* only (`gear_guard.py:37-38`), never a gate source — `camera.gear_guard_live` gates on `LIVE_CAM`/`MOTION_CAM` (`gear_guard.py:24`), so a vehicle whose only camera flag is `INTERIOR_CAMERA` gets no camera entity. | s28 scoped it out (`tests/test_camera.py::test_no_interior_entity_even_with_interior_flag`); an interior-only vehicle gets nothing (`::test_not_created_without_camera_flags`). This R1T does not advertise the flag (`CAPABILITY_MATRIX.md:83`), so it cannot be probed on the available hardware. |
-| Combined honk+flash | `HONK_AND_FLASH_LIGHTS` — **not** a VASCommand; live REJECTED twice | Button reverted; not a cloud path |
+| Combined honk+flash | `HONK_AND_FLASH_LIGHTS` — not a VASCommand **in 3.15.0**; live REJECTED twice. Corrected 2026-08-31 (s32): it *was* one in all 25 corpus versions 1.0.3–2.6.0, cloud+ble. A dropped command, not one that never existed. | Button reverted; not a cloud path in the shipping app |
 | Trip planner / active trip / add-stop / trailers / satmap | `ACTIVE_TRIP`, `V_TRIP`, `TRIP_ADD_STOP`, `TRIP_PLANNER_TRAILERS`, `V_SATMAP` | Round 4 non-goal. Navigation `notify` already exists. |
 | Phone-key management UI | `KEY_PAAK`, `KEY_FOB_2`, `PIN_PROFILE`, `ORPHANED_PHONE_KEY_RECOVERY_HANDLING` | Pair button + counts only; Round 4 non-goal |
 
@@ -83,7 +83,7 @@ story. Inclusive OR: a wired sendable may also appear here (`OPEN_LIFTGATE`,
 |------|---------|
 | Shop, account, Stripe, MapLibre, charging-network signup | Not HA-shaped (Round 5) |
 | Energy graphs / cold-weather bar charts | Not an entity/service; sensors for SoC already exist |
-| Per-door unlock / `UNLOCK_ALL_AND_OPEN_WINDOWS` | HA extras **absent from APK 3.15.0** — not an APK gap (lower bound) |
+| Per-door unlock / `UNLOCK_ALL_AND_OPEN_WINDOWS` | **Miscategorized — corrected 2026-08-31 (s32).** "Absent from APK 3.15.0" is TRUE and stays enforced (`test_apk_transcription.py`), but "HA extras" is wrong: these are app commands 3.15.0 **dropped**. The historical corpus carries `UNLOCK_DRIVER_DOOR`, `UNLOCK_PASSENGER_DOOR` and `UNLOCK_ALL_AND_OPEN_WINDOWS` as full dual-transport VASCommands in 19 versions (1.5.1–2.6.0), and `UNLOCK_USER_PREFERENCES_AND_DISABLE_ALARM` in 25 (1.0.3–2.6.0). Held out of the probe queue: all four were live-REJECTED `CONFLICT/VEHICLE_COMMAND_ERROR` on 2026-08-26 ([`COMMAND_COVERAGE.md`](COMMAND_COVERAGE.md)). **Re-entry condition:** a firmware change, or a materially different vehicle state — per Principle -1 above, a CONFLICT is not a capability failure. They stay in the enum. |
 | `OPEN_LIFTGATE` / `OPEN_TAILGATE` | Already wired, disabled by default. Tailgate actuation owner-prohibited (garage). |
 | `START_GEAR_GUARD_MASTER_SESSION` | Already wired by s28 as `camera.gear_guard_live` (`camera.py:388`). No stop VASCommand exists; tear-down is local. Clip download (`START_VIDEO_DOWNLOADING_SESSION`) is a different path and stays unwired. |
 | Unpopulated `tirePressureStatusValid*` / `cabinHoldNotification` | Not missing; subscribed and empty. Stay. |

--- a/docs/development/apk/REGENERATION.md
+++ b/docs/development/apk/REGENERATION.md
@@ -75,7 +75,7 @@ the seven-command table would lose its provenance.
 
 | | source | on disk today | findings resting on it |
 |---|---|---|---|
-| the **artifacts** — the nine `.java` beside this file | `jadx` of **3.15.0** build 4804, 32,941 files | the nine files, yes; the tree they came from, no | the seven invalid-wrapper commands; `isParallaxRequestOnly`; the two wrapper generators; `VehicleFeature`; the five `vehicleState` documents |
+| the **artifacts** — the nine `.java` beside this file | `jadx` of **3.15.0** build 4804, 32,941 files | the nine files, yes; **and the tree they came from, at `.apk/3.15.0/jadx/sources`** (corrected 2026-08-31, s32) | the seven invalid-wrapper commands; `isParallaxRequestOnly`; the two wrapper generators; `VehicleFeature`; the five `vehicleState` documents |
 | the **tree** `com.rivian.android.consumer/` | **3.6.0**, versionCode 3989 | yes | the command-state terminality vocabulary; the client-side cancellation of the command-state stream; the 18/6/0/8/91 subscription-vs-poll counts; `ParallaxAttributes` |
 
 The section above ("The app") describes how the **artifacts** were produced and
@@ -86,7 +86,7 @@ File counts, each with the command that produced it:
 
 | figure | source | reproduces? |
 |---|---|---|
-| 32,941 | `jadx` run on 3.15.0, per this file's "The command" section | not re-runnable — that tree is not on disk |
+| 32,941 | `jadx` run on 3.15.0, per this file's "The command" section | **yes, 2026-08-31** — `find .apk/3.15.0 -name '*.java' \| wc -l` returns exactly 32,941. An earlier revision said "not re-runnable — that tree is not on disk"; it is on disk and gitignored (`.apk/`) |
 | **31,097** | `find com.rivian.android.consumer/java_src -name "*.java" \| wc -l` | **yes, 2026-08-19** |
 | **71,735** | `find com.rivian.android.consumer -type f \| wc -l` | **yes, 2026-08-19** |
 | 31,105 | this file's opening paragraph, "the 31,105-file apktool tree" | **no — unreproduced, source unknown** |

--- a/scripts/apk_corpus_sweep.py
+++ b/scripts/apk_corpus_sweep.py
@@ -81,7 +81,35 @@ SRC_DUMPS: dict[str, str] = {
 # The one dump that lives in the repo instead of ~/src.
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REPO_DUMPS: dict[str, Path] = {
+    "2.6.1": REPO_ROOT / ".apk" / "2.6.1" / "jadx" / "sources",
+    "2.7.0": REPO_ROOT / ".apk" / "2.7.0" / "jadx" / "sources",
+    "2.8.0": REPO_ROOT / ".apk" / "2.8.0" / "jadx" / "sources",
+    "2.10.0": REPO_ROOT / ".apk" / "2.10.0" / "jadx" / "sources",
+    "2.10.1": REPO_ROOT / ".apk" / "2.10.1" / "jadx" / "sources",
+    "2.19.1": REPO_ROOT / ".apk" / "2.19.1" / "jadx" / "sources",
+    "2.20.0": REPO_ROOT / ".apk" / "2.20.0" / "jadx" / "sources",
+    "2.21.0": REPO_ROOT / ".apk" / "2.21.0" / "jadx" / "sources",
+    "3.0.0": REPO_ROOT / ".apk" / "3.0.0" / "jadx" / "sources",
+    "3.1.0": REPO_ROOT / ".apk" / "3.1.0" / "jadx" / "sources",
+    "3.1.1": REPO_ROOT / ".apk" / "3.1.1" / "jadx" / "sources",
+    "3.3.0": REPO_ROOT / ".apk" / "3.3.0" / "jadx" / "sources",
+    "3.4.0": REPO_ROOT / ".apk" / "3.4.0" / "jadx" / "sources",
+    "3.5.0": REPO_ROOT / ".apk" / "3.5.0" / "jadx" / "sources",
+    "3.5.1": REPO_ROOT / ".apk" / "3.5.1" / "jadx" / "sources",
+    "3.6.0": REPO_ROOT / ".apk" / "3.6.0" / "jadx" / "sources",
+    "3.6.1": REPO_ROOT / ".apk" / "3.6.1" / "jadx" / "sources",
+    "3.7.0": REPO_ROOT / ".apk" / "3.7.0" / "jadx" / "sources",
+    "3.8.0": REPO_ROOT / ".apk" / "3.8.0" / "jadx" / "sources",
+    "3.9.0": REPO_ROOT / ".apk" / "3.9.0" / "jadx" / "sources",
+    "3.10.0": REPO_ROOT / ".apk" / "3.10.0" / "jadx" / "sources",
+    "3.11.0": REPO_ROOT / ".apk" / "3.11.0" / "jadx" / "sources",
+    "3.12.0": REPO_ROOT / ".apk" / "3.12.0" / "jadx" / "sources",
+    "3.12.1": REPO_ROOT / ".apk" / "3.12.1" / "jadx" / "sources",
+    "3.13.0": REPO_ROOT / ".apk" / "3.13.0" / "jadx" / "sources",
+    "3.13.1": REPO_ROOT / ".apk" / "3.13.1" / "jadx" / "sources",
+    "3.14.0": REPO_ROOT / ".apk" / "3.14.0" / "jadx" / "sources",
     "3.15.0": REPO_ROOT / ".apk" / "3.15.0" / "jadx" / "sources",
+    "3.16.0": REPO_ROOT / ".apk" / "3.16.0" / "jadx" / "sources",
 }
 
 # --- command extraction ------------------------------------------------------
@@ -849,7 +877,11 @@ def report(result: dict) -> None:
                 if on
             ]
         )
-        print(f"    {command['name']:48s} {wrappers or '-':20s} {command['class']}")
+        # `name` is None for a wrapper-less class -- the same None the ledger
+        # sort key already guards. A class with no wrapper carries no command
+        # name, and 3.16.0 has four of them.
+        label = command["name"] or "(no command name)"
+        print(f"    {label:48s} {wrappers or '-':20s} {command['class']}")
     print(f"  documents {len(result['documents'])}")
     for document in result["documents"]:
         for operation in document["operations"]:
@@ -877,7 +909,11 @@ def report(result: dict) -> None:
 COHORTS: dict[str, str] = {
     "sources": "A/sources (1.x + 2.0.0_beta; decompiler unrecorded)",
     "java_src": "B/java_src (2.2.0+; decompiler unrecorded)",
-    ".": "C/jadx (3.15.0 build 4804; jadx, documented)",
+    # 29 trees, 2.6.1 to 3.16.0, all decompiled here with jadx 1.5.6
+    # from APKMirror bundles. Unlike cohorts A and B, whose decompiler was
+    # never recorded, this one has documented provenance -- so counts inside
+    # it are comparable to each other, and 3.15.0 remains its ground truth.
+    ".": "C/jadx (29 trees 2.6.1-3.16.0; jadx 1.5.6, documented)",
 }
 
 

--- a/scripts/apk_corpus_sweep.py
+++ b/scripts/apk_corpus_sweep.py
@@ -1,0 +1,1217 @@
+#!/usr/bin/env python3
+"""Sweep every decompiled Rivian Android dump for commands, queries and features.
+
+The integration's command list, its `vehicleState` field set and its capability
+gates were all reconstructed from the app. Each was read out of ONE dump, by
+hand, at the time it was needed -- which is why nobody can say when a name
+appeared, when it changed spelling, or whether a name we ship was ever real.
+This walks all of the dumps at once so those questions have a mechanical answer.
+
+Three deliberate constraints, each of them a bug we already shipped:
+
+CORPUS IS AN ALLOWLIST, NEVER A GLOB. `~/src/rivian*` also matches
+`rivian-dump/`, which is ABRP telemetry JSON and not an app dump at all. The
+directory names are irregular on purpose-of-history -- `rivian_2.0.0_beta` has
+an underscore, `rivian_2.5.0 beta` has a SPACE, and 2.5.1 onward are named for
+the package -- so they are spelled out below and every one is a `Path`, never a
+string spliced into a shell word.
+
+LAYOUT IS DISCOVERED, NOT DERIVED FROM THE VERSION. The sources sit under
+`sources/` in the 1.x dumps AND in `rivian_2.0.0_beta`, under `java_src/` from
+2.2.0 on, and directly under the root of the repo-local jadx tree. There is no
+rule mapping version to layout, so nothing here builds a package subpath: it
+walks from the root and matches on basename and file content. It also walks
+`*.java` only -- a `.dex` blob under `resources/` carries the same byte
+sequences and inflates every count that touches it.
+
+MATCHES ARE WHOLE-WORD. `wiperFluidState` is a real field and also a prefix of
+the Room column `wiperFluidStateUpdatedTimestamp`; substring matching silently
+conflates the two. Every name match here is `\\b`-anchored.
+
+A version that yields no commands is reported as an ERROR rather than skipped,
+because "the parse broke" and "the app had no commands" look identical in a
+summary line and only one of them is ever true.
+
+Usage:
+    python scripts/apk_corpus_sweep.py [--src-root ~/src] [--only VERSION ...] [--json]
+    python scripts/apk_corpus_sweep.py --ledger    # one row per command
+    python scripts/apk_corpus_sweep.py --sensors   # four sensor-surface deltas
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from collections.abc import Iterable
+import json
+from pathlib import Path
+import re
+import sys
+
+# Version -> literal directory name under --src-root. Spelled out, never globbed.
+# `2.5.0_beta` really does live in a directory with a space in it.
+SRC_DUMPS: dict[str, str] = {
+    "1.0.3": "rivian_1.0.3",
+    "1.2.1": "rivian_1.2.1",
+    "1.3.0": "rivian_1.3.0",
+    "1.3.1": "rivian_1.3.1",
+    "1.4.0": "rivian_1.4.0",
+    "1.4.1": "rivian_1.4.1",
+    "1.5.1": "rivian_1.5.1",
+    "1.6.0": "rivian_1.6.0",
+    "1.7.0": "rivian_1.7.0",
+    "1.7.1": "rivian_1.7.1",
+    "1.8.0": "rivian_1.8.0",
+    "1.9.0": "rivian_1.9.0",
+    "1.10.0": "rivian_1.10.0",
+    "1.11.0": "rivian_1.11.0",
+    "1.12.0": "rivian_1.12.0",
+    "1.13.0": "rivian_1.13.0",
+    "1.14.0": "rivian_1.14.0",
+    "1.15.0": "rivian_1.15.0",
+    "2.0.0_beta": "rivian_2.0.0_beta",
+    "2.2.0": "rivian_2.2.0",
+    "2.3.0": "rivian_2.3.0",
+    "2.4.0": "rivian_2.4.0",
+    "2.5.0_beta": "rivian_2.5.0 beta",
+    "2.5.1": "com_rivian_android_consumer_v2.5.1",
+    "2.6.0": "com_rivian_android_consumer_v2.6.0",
+}
+
+# The one dump that lives in the repo instead of ~/src.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_DUMPS: dict[str, Path] = {
+    "3.15.0": REPO_ROOT / ".apk" / "3.15.0" / "jadx" / "sources",
+}
+
+# --- command extraction ------------------------------------------------------
+
+VAS_COMMAND_FILES = ("VASCommand.java", "VASCommandKt.java")
+
+# `public static final class OpenFrunk extends VASCommand {`
+COMMAND_CLASS_RE = re.compile(r"\bclass\s+(\w+)\s+extends\s+VASCommand\b")
+
+# The wrapper factories. `$default` is the Kotlin default-argument bridge; the
+# first argument is always the companion, the second carries the name.
+CLOUD_CALL_RE = re.compile(
+    r"\bgenerateCloudDataWrapper(?:\$default)?\s*\(\s*[^,()]+,\s*"
+    # `(?:get)?` matters: jadx renders the Kotlin property as
+    # `VASCommandKt.getCABIN_HVAC_DEFROST_DEFOG()`. Without it the const group
+    # cannot match at `get...`, so the engine backtracks, discards the
+    # `VASCommandKt.` prefix and matches `VASC` -- silently renaming ten
+    # climate commands after a fragment of the class name.
+    r'(?:"(?P<literal>[^"]*)"|(?:VASCommandKt\.)?(?:get)?(?P<const>[A-Z][A-Z0-9_]{2,}))'
+)
+BLE_CALL_RE = re.compile(
+    r"\bgenerateBLEDataWrapper(?:\$default)?\s*\(\s*[^,()]+,\s*"
+    r"(?:VASCommandKt\.)?(?:get)?(?P<const>BLE_[A-Z0-9_]+)"
+)
+CLOUD_PRESENT_RE = re.compile(r"\bgenerateCloudDataWrapper\b")
+BLE_PRESENT_RE = re.compile(r"\bgenerateBLEDataWrapper\b")
+
+# 3.15.0 only, and a third form rather than a variant of the first: ten classes
+# build their wrapper with `generateInvalidCloudDataWrapper("PET_COMFORT_ON")`
+# -- the Parallax-routed and px-request-only commands, which carry a real name
+# but are NOT sendable over the VAS cloud path. Folding these into `cloud` would
+# overstate what the integration can send; dropping them would lose ten names,
+# so they get their own column.
+INVALID_CLOUD_CALL_RE = re.compile(
+    r"\bgenerateInvalidCloudDataWrapper\s*\(\s*"
+    r'(?:"(?P<literal>[^"]*)"|(?:VASCommandKt\.)?(?P<const>[A-Z][A-Z0-9_]{2,}))'
+)
+INVALID_CLOUD_PRESENT_RE = re.compile(r"\bgenerateInvalidCloudDataWrapper\b")
+
+# `public static final String CLOUD_START_CHARGING = "START_CHARGING";`
+STRING_CONST_RE = re.compile(r"\bstatic\s+final\s+String\s+(\w+)\s*=\s*\"([^\"]*)\"")
+
+# jadx gives up on some constructors and emits a register dump instead of Java.
+# The command name survives as a bare literal (`java.lang.String r3 = "..."`),
+# so an all-caps literal inside the class block is the last-resort name.
+SCREAMING_LITERAL_RE = re.compile(r'"([A-Z][A-Z0-9_]{2,})"')
+
+# --- vehicleState document extraction ----------------------------------------
+
+# The Apollo-generated operation text. Whole-word so a longer identifier ending
+# in `vehicleState` cannot masquerade as the operation root.
+VEHICLE_STATE_MARKER = re.compile(r"\bvehicleState\(id:")
+JAVA_STRING_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
+GRAPHQL_TOKEN_RE = re.compile(r"\.{3}|[{}()]|\$?[A-Za-z_][A-Za-z0-9_]*|:|.")
+
+# --- feature extraction ------------------------------------------------------
+
+VEHICLE_FEATURE_FILE = "VehicleFeature.java"
+# `TAILGATE_CMD("TAILGATE_CMD"),` -- member and server-facing featureName differ
+# for 19 of the 64 members in 3.15.0, so both columns are kept.
+ENUM_MEMBER_RE = re.compile(
+    r"^\s*([A-Z][A-Z0-9_]*)\(\"([^\"]*)\"\)\s*[,;]", re.MULTILINE
+)
+
+
+# --- sensor-surface extraction -----------------------------------------------
+#
+# Four surfaces, four DIFFERENT metrics, because the four integration-side sets
+# they are compared against are four different shapes. Sharing one "count every
+# name" metric across them is the mistake this block exists to avoid: it makes
+# every number look comparable and none of them actually is.
+
+# (1) vehicleState. The metric here is NOT `graphql_field_names()`. That one
+# unions names at ANY depth, which for wcm.java counts 138; the number that is
+# comparable to `VEHICLE_STATE_API_FIELDS` -- a set of TOP-LEVEL subscribed
+# names -- is the depth-1 count, which is 128. Both measurements are correct and
+# only one answers the question, so this replicates the depth-1 walk from
+# `scripts/gates/helpers/apk_vehicle_state_fields.py` rather than reusing the
+# tokenizer. Its numbers reconcile with that helper exactly: wcm 128, cdm 122,
+# apj 8, h9l 1, lel 1, union 137 -- the same 137 that `scripts/gates/f4.sh`
+# asserts.
+#
+# The helper hard-codes `$vehicleID` because it only ever reads the nine
+# pre-flight classes. The corpus spans 26 builds, so the variable name is a
+# capture here, not a literal.
+VEHICLE_STATE_ROOT_RE = re.compile(r"vehicleState\(id: \$\w+\) \{")
+VEHICLE_STATE_FRAGMENT_RE = re.compile(r"fragment (\w+) on VehicleState \{")
+
+# (2) Parallax RVMs. The table is a Kotlin enum whose CLASS name is obfuscated
+# and build-specific (`l6e`, `iol` in 3.15.0), so the anchor is the property,
+# which R8 leaves alone: `private final String rvmName;`. jadx renders the enum
+# two ways depending on whether it could restore the `enum` modifier, so both
+# forms are matched.
+RVM_TABLE_MARKER_RE = re.compile(r"\bprivate final String rvmName;")
+RVM_ENUM_CTOR_RE = re.compile(
+    r'new \w+\(\s*"[A-Z][A-Z0-9_]*"\s*,\s*\d+\s*,\s*"([a-z][\w.]*\.[\w.]+)"'
+)
+RVM_SIMPLE_ENUM_RE = re.compile(
+    r'^\s*[A-Z][A-Z0-9_]*\("([a-z][\w.]*\.[\w.]+)"\)\s*[,;]', re.MULTILINE
+)
+# Parallax did not exist before 3.x. `ParallaxAttributes.java` is the marker for
+# "this build has the Parallax command surface at all" -- it is absent from every
+# 1.x and 2.x tree, so the historical corpus contributes NOTHING to this surface
+# and a zero there is a fact about the app, not a parse failure.
+PARALLAX_ATTRIBUTES_FILE = "ParallaxAttributes.java"
+
+# (3) VehicleFeature is already extracted by `extract_features`; the surface just
+# compares it against the transcription.
+
+# (4) Charging / wallbox. Unlike vehicleState there is no single operation root,
+# so the surface is defined by the roots the INTEGRATION itself sends -- anything
+# else would be measuring the app's charging-network features, which this
+# integration does not implement and cannot be in deficit against.
+CHARGING_ROOT_RE = re.compile(
+    r"\b(?:getRegisteredWallboxes|getWallboxStatus|chargingSchedules"
+    r"|setChargingSchedules|getLiveSessionData)\b|\bchargingSession\("
+)
+GRAPHQL_OPERATION_RE = re.compile(r"\s*(query|subscription|mutation)\b")
+
+# The vendored schema splits this surface across TWO files: the wallbox record
+# lives in `charging.graphql`, not `gateway.graphql`. Naming only the gateway
+# would report all 17 `WallboxRecord` fields as undeclared.
+SCHEMA_FILES = ("gateway.graphql", "charging.graphql")
+# Arg-bearing fields are declared `chargingSession(vehicleId: String!): T`, so
+# the argument list has to be optional here. Without it the Query/Mutation roots
+# drop out and the delta reports five phantom undeclared names.
+SCHEMA_FIELD_RE = re.compile(r"^  (\w+)(?:\([^)]*\))?:", re.MULTILINE)
+CHARGING_SCHEMA_TYPES = (
+    "GeoCoordinates",
+    "OK",
+    "ChargingChartData",
+    "ChargingLiveData",
+    "ChargingSchedule",
+    "ChargingSession",
+    "InputChargingSchedule",
+    "WallboxRecord",
+    "LiveSessionData",
+    "ChargingSessionSummary",
+    "ChargingSessionSummaryMeta",
+)
+# `Query`/`Mutation`/`Subscription`/`Vehicle` are deliberately NOT in that list:
+# they declare 70-odd names about login, orders and images that have nothing to
+# do with charging, and folding them in buries a two-name delta under 73 lines of
+# noise. Only the roots that reach the charging types are taken, and each one is
+# checked to exist so a schema rename cannot silently drop it.
+CHARGING_SCHEMA_ROOTS = (
+    "getRegisteredWallboxes",
+    "getWallboxStatus",
+    "getVehicle",
+    "chargingSchedules",
+    "setChargingSchedules",
+    "chargingSession",
+    "getLiveSessionData",
+)
+SCHEMA_TYPE_RE = r"^(?:type|input) %s [^{]*\{\n(.*?)\n\}"
+SCHEMA_ROOT_RE = r"^  %s(?:\([^)]*\))?:"
+
+# BLE-only commands are NOT part of any sensor surface and never belong in a
+# delta table: a command the app can only send over Bluetooth is not a field the
+# integration is failing to read. They are reported as an appendix so that a
+# reader who sees them in the ledger can tell why they are excluded here.
+# `WINCH_*` (1.0.3-1.4.1) and `PAUSE_*` (1.0.3-2.6.0) are the two families.
+
+
+def version_key(version: str) -> tuple[int, int, int, int]:
+    """Sort 1.9.0 before 1.10.0, and let both `_beta` spellings through."""
+    base, _, suffix = version.partition("_")
+    parts = [int(p) for p in base.split(".")]
+    while len(parts) < 3:
+        parts.append(0)
+    # A beta precedes the release it is named for; neither of ours collides.
+    return (parts[0], parts[1], parts[2], 0 if suffix else 1)
+
+
+def unescape_java(literal: str) -> str:
+    simple = {"n": "\n", "t": "\t", "r": "\r", '"': '"', "\\": "\\", "'": "'"}
+    out: list[str] = []
+    i = 0
+    while i < len(literal):
+        char = literal[i]
+        if char == "\\" and i + 1 < len(literal):
+            nxt = literal[i + 1]
+            if nxt in simple:
+                out.append(simple[nxt])
+                i += 2
+                continue
+            if nxt == "u" and i + 6 <= len(literal):
+                try:
+                    out.append(chr(int(literal[i + 2 : i + 6], 16)))
+                    i += 6
+                    continue
+                except ValueError:
+                    pass
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def balanced_block(text: str, open_brace: int) -> str:
+    """Return the `{...}` block starting at `open_brace`, braces balanced."""
+    depth = 0
+    for index in range(open_brace, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_brace : index + 1]
+    return text[open_brace:]
+
+
+def graphql_field_names(document: str) -> list[str]:
+    """Field names selected anywhere in a GraphQL document.
+
+    Written as a tokenizer rather than a regex because the interesting names sit
+    in selection sets while the uninteresting ones -- operation names, variable
+    types, fragment type conditions -- sit outside them, and only nesting depth
+    tells the two apart.
+    """
+    tokens = [t for t in GRAPHQL_TOKEN_RE.findall(document) if not t.isspace()]
+    fields: list[str] = []
+    depth = 0
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "(":
+            # Argument or variable-definition list: skip it whole.
+            paren = 0
+            while index < len(tokens):
+                if tokens[index] == "(":
+                    paren += 1
+                elif tokens[index] == ")":
+                    paren -= 1
+                    if paren == 0:
+                        break
+                index += 1
+            index += 1
+            continue
+        if token == "{":
+            depth += 1
+            index += 1
+            continue
+        if token == "}":
+            depth -= 1
+            index += 1
+            continue
+        if token == "...":
+            # Fragment spread or inline fragment: `...name` / `... on Type`.
+            index += 2 if index + 1 < len(tokens) and tokens[index + 1] == "on" else 1
+            index += 1
+            continue
+        if depth >= 1 and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", token):
+            if index + 1 < len(tokens) and tokens[index + 1] == ":":
+                # `alias: field` -- the field is what follows the colon.
+                index += 2
+                continue
+            if token != "__typename":
+                fields.append(token)
+        index += 1
+    seen = set()
+    unique: list[str] = []
+    for name in fields:
+        if name not in seen:
+            seen.add(name)
+            unique.append(name)
+    return unique
+
+
+def extract_commands(sources: dict[str, str]) -> list[dict]:
+    """Command records from the VASCommand sources of one dump.
+
+    A record is one `X extends VASCommand` class. `cloud` means the class builds
+    a CloudDataWrapper, so the command is cloud-sendable; a class with only
+    `ble` is BLE-only and cannot be sent from the integration.
+    """
+    # Named constants can be declared in either file; resolve across both.
+    constants: dict[str, str] = {}
+    for text in sources.values():
+        for name, value in STRING_CONST_RE.findall(text):
+            constants[name] = value
+
+    commands: list[dict] = []
+    for text in sources.values():
+        for match in COMMAND_CLASS_RE.finditer(text):
+            brace = text.find("{", match.end())
+            if brace == -1:
+                continue
+            block = balanced_block(text, brace)
+            class_name = match.group(1)
+
+            cloud_names: list[str] = []
+            for call in CLOUD_CALL_RE.finditer(block):
+                literal, const = call.group("literal"), call.group("const")
+                name = literal if literal is not None else constants.get(const, const)
+                if name and name not in cloud_names:
+                    cloud_names.append(name)
+
+            has_cloud = bool(CLOUD_PRESENT_RE.search(block))
+            if has_cloud and not cloud_names:
+                cloud_names = [
+                    literal
+                    for literal in dict.fromkeys(SCREAMING_LITERAL_RE.findall(block))
+                    if "_" in literal and len(literal) >= 8
+                ]
+
+            ble_consts = list(
+                dict.fromkeys(m.group("const") for m in BLE_CALL_RE.finditer(block))
+            )
+            has_ble = bool(BLE_PRESENT_RE.search(block))
+
+            invalid_names: list[str] = []
+            for call in INVALID_CLOUD_CALL_RE.finditer(block):
+                literal, const = call.group("literal"), call.group("const")
+                name = literal if literal is not None else constants.get(const, const)
+                if name and name not in invalid_names:
+                    invalid_names.append(name)
+            has_invalid = bool(INVALID_CLOUD_PRESENT_RE.search(block))
+
+            if cloud_names:
+                name = cloud_names[0]
+            elif invalid_names:
+                name = invalid_names[0]
+            elif ble_consts:
+                name = ble_consts[0][len("BLE_") :]
+            else:
+                # No wrapper of any kind, so the class carries no command-name
+                # string. `PauseFrunk`, `PauseLiftgate`, `PauseTonneauCover` each
+                # have a literal `cloudData = null`; `ParallaxCommand` takes its
+                # wrapper as a constructor parameter. Falling back to the class
+                # name here invented four commands that the app never names.
+                name = None
+
+            commands.append(
+                {
+                    "name": name,
+                    "class": class_name,
+                    "cloud": has_cloud,
+                    "ble": has_ble,
+                    "cloud_invalid": has_invalid,
+                    "cloud_names": cloud_names,
+                    "cloud_invalid_names": invalid_names,
+                    "ble_constants": ble_consts,
+                }
+            )
+    # `name` is None for wrapper-less classes, which cannot be compared to str.
+    commands.sort(key=lambda c: (c["name"] or "", c["class"]))
+    return commands
+
+
+def extract_documents(hits: list[tuple[str, str]]) -> list[dict]:
+    """One record per file whose content carries a `vehicleState(id:` document."""
+    documents: list[dict] = []
+    for relative_path, text in hits:
+        operations: list[dict] = []
+        for match in JAVA_STRING_RE.finditer(text):
+            body = unescape_java(match.group(1))
+            if not VEHICLE_STATE_MARKER.search(body):
+                continue
+            head = re.match(r"\s*(query|subscription|mutation)\s+(\w+)", body)
+            operations.append(
+                {
+                    "operation": head.group(2) if head else None,
+                    "type": head.group(1) if head else None,
+                    "fields": graphql_field_names(body),
+                }
+            )
+        documents.append({"file": relative_path, "operations": operations})
+    documents.sort(key=lambda d: d["file"])
+    return documents
+
+
+def extract_features(text: str) -> list[dict]:
+    """(member, featureName) pairs from the VehicleFeature enum.
+
+    Both columns matter: the member is what the app's own code branches on, and
+    the featureName is what the server actually emits in `supportedFeatures`.
+    """
+    return [
+        {"member": member, "feature_name": feature}
+        for member, feature in ENUM_MEMBER_RE.findall(text)
+    ]
+
+
+def selection_body(document: str, after_open_brace: int) -> str:
+    """The body of a `{...}` whose opening brace has already been consumed."""
+    depth = 1
+    index = after_open_brace
+    while depth and index < len(document):
+        if document[index] == "{":
+            depth += 1
+        elif document[index] == "}":
+            depth -= 1
+        index += 1
+    return document[after_open_brace : index - 1]
+
+
+def split_top_level(body: str) -> list[str]:
+    """The depth-1 tokens of a selection-set body.
+
+    Replicated from `scripts/gates/helpers/apk_vehicle_state_fields.py`. It is
+    duplicated rather than imported because that helper reads the nine
+    pre-flight classes by path and this reads 26 whole trees; what has to match
+    between them is the METRIC, and it does -- see the reconciliation in the
+    comment above `VEHICLE_STATE_ROOT_RE`.
+    """
+    out: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in body:
+        if char == "{":
+            depth += 1
+            current.append(char)
+        elif char == "}":
+            depth -= 1
+            current.append(char)
+            if depth == 0:
+                out.append("".join(current).strip())
+                current = []
+        elif depth == 0 and char.isspace():
+            if current:
+                out.append("".join(current).strip())
+                current = []
+        else:
+            current.append(char)
+    if current:
+        out.append("".join(current).strip())
+    return [token for token in out if token]
+
+
+def selection_names(body: str, fragments: dict[str, str]) -> set[str]:
+    """Depth-1 field names of a selection set, resolving fragment spreads."""
+    names: set[str] = set()
+    for token in split_top_level(body):
+        if token.startswith("..."):
+            spread = token[3:]
+            if spread in fragments:
+                names |= selection_names(fragments[spread], fragments)
+            continue
+        if token.startswith("{") or token == "__typename":
+            # A nested selection set belongs to the field before it, and
+            # `__typename` is Apollo bookkeeping rather than a subscribed name.
+            continue
+        names.add(token)
+    return names
+
+
+def vehicle_state_field_names(document: str) -> set[str]:
+    """Top-level `VehicleState` names selected by one GraphQL document.
+
+    The depth-1 metric, not the union-at-any-depth one -- see the comment on
+    `VEHICLE_STATE_ROOT_RE` for why the difference matters.
+    """
+    fragments = {
+        match.group(1): selection_body(document, match.end())
+        for match in VEHICLE_STATE_FRAGMENT_RE.finditer(document)
+    }
+    names: set[str] = set()
+    for match in VEHICLE_STATE_ROOT_RE.finditer(document):
+        names |= selection_names(selection_body(document, match.end()), fragments)
+    return names
+
+
+def extract_rvm_names(text: str) -> set[str]:
+    """RVM names from one obfuscated Kotlin enum table, or nothing."""
+    if not RVM_TABLE_MARKER_RE.search(text):
+        return set()
+    return set(RVM_ENUM_CTOR_RE.findall(text)) | set(RVM_SIMPLE_ENUM_RE.findall(text))
+
+
+def charging_field_names(document: str) -> set[str]:
+    """Field names of one charging/wallbox operation, at any depth.
+
+    Any depth is right HERE and wrong for `vehicleState`: the charging types are
+    two levels deep (`chargingSession { chartData { soc } }`) and the schema
+    declares every one of those names, so a depth-1 metric would compare a
+    handful of container names against 123 declared fields.
+    """
+    if not GRAPHQL_OPERATION_RE.match(document) or not CHARGING_ROOT_RE.search(
+        document
+    ):
+        return set()
+    return set(graphql_field_names(document))
+
+
+# --- the integration's own sets, read from source ----------------------------
+#
+# Parsed, never imported. Importing `const.py` drags in `homeassistant`, and the
+# whole point of this script is that it runs against a corpus that lives outside
+# any virtualenv.
+
+
+def _eval_set_expr(node: ast.expr, env: dict[str, set[str]]) -> set[str] | None:
+    """Evaluate the tiny expression language `const.py`'s field sets are built in.
+
+    That is: set literals, `frozenset({...})`, names bound earlier in the module,
+    and `|`/`-` between them. Anything else returns None rather than guessing.
+    """
+    if isinstance(node, ast.Set):
+        values = {e.value for e in node.elts if isinstance(e, ast.Constant)}
+        return values if len(values) == len(node.elts) else None
+    if isinstance(node, ast.Call):
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else None
+        if name in {"frozenset", "set"} and len(node.args) == 1:
+            return _eval_set_expr(node.args[0], env)
+        return None
+    if isinstance(node, ast.Name):
+        return env.get(node.id)
+    if isinstance(node, ast.BinOp):
+        left = _eval_set_expr(node.left, env)
+        right = _eval_set_expr(node.right, env)
+        if left is None or right is None:
+            return None
+        if isinstance(node.op, ast.BitOr):
+            return left | right
+        if isinstance(node.op, ast.Sub):
+            return left - right
+    return None
+
+
+def _module_sets(path: Path) -> dict[str, set[str]]:
+    """Every module-level name in `path` that resolves to a set of strings."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    env: dict[str, set[str]] = {}
+    for statement in tree.body:
+        if isinstance(statement, ast.Assign) and len(statement.targets) == 1:
+            target, value = statement.targets[0], statement.value
+        elif isinstance(statement, ast.AnnAssign) and statement.value is not None:
+            target, value = statement.target, statement.value
+        else:
+            continue
+        if not isinstance(target, ast.Name):
+            continue
+        resolved = _eval_set_expr(value, env)
+        if resolved is not None:
+            env[target.id] = resolved
+    return env
+
+
+def integration_vehicle_state_fields(repo_root: Path) -> set[str]:
+    env = _module_sets(repo_root / "custom_components" / "rivian" / "const.py")
+    return env["VEHICLE_STATE_API_FIELDS"]
+
+
+def integration_rvm_names(repo_root: Path) -> set[str]:
+    """The keys of `RVM_DECODERS` -- the RVMs this fork can actually decode."""
+    path = repo_root / "custom_components" / "rivian" / "rivian_client" / "parallax.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for statement in tree.body:
+        target = None
+        if isinstance(statement, ast.AnnAssign):
+            target = statement.target
+        elif isinstance(statement, ast.Assign) and len(statement.targets) == 1:
+            target = statement.targets[0]
+        if not isinstance(target, ast.Name) or target.id != "RVM_DECODERS":
+            continue
+        value = statement.value
+        if isinstance(value, ast.Dict):
+            return {
+                key.value
+                for key in value.keys
+                if isinstance(key, ast.Constant) and isinstance(key.value, str)
+            }
+    raise SystemExit(f"RVM_DECODERS not found in {path}")
+
+
+def integration_feature_pairs(repo_root: Path) -> set[tuple[str, str]]:
+    """`(member, featureName)` from the transcription, not from `const.py`.
+
+    The capability flags are not a `const.py` symbol: entity descriptions name
+    the seven the integration gates on, one string at a time. `VEHICLE_FEATURES`
+    in `tests/apk/transcription.py` is the recorded whole enum, and it is what a
+    64-member app table is comparable to.
+    """
+    path = repo_root / "tests" / "apk" / "transcription.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for statement in tree.body:
+        target = None
+        if isinstance(statement, ast.AnnAssign):
+            target = statement.target
+        elif isinstance(statement, ast.Assign) and len(statement.targets) == 1:
+            target = statement.targets[0]
+        if not isinstance(target, ast.Name) or target.id != "VEHICLE_FEATURES":
+            continue
+        value = statement.value
+        if isinstance(value, (ast.Tuple, ast.List)):
+            pairs: set[tuple[str, str]] = set()
+            for element in value.elts:
+                if (
+                    isinstance(element, (ast.Tuple, ast.List))
+                    and len(element.elts) == 2
+                ):
+                    first, second = element.elts
+                    if isinstance(first, ast.Constant) and isinstance(
+                        second, ast.Constant
+                    ):
+                        pairs.add((first.value, second.value))
+            return pairs
+    raise SystemExit(f"VEHICLE_FEATURES not found in {path}")
+
+
+def integration_charging_fields(repo_root: Path) -> set[str]:
+    """Charging/wallbox field names declared by the vendored schemas."""
+    schemas = repo_root / "custom_components" / "rivian" / "rivian_client" / "schemas"
+    fields: set[str] = set()
+    seen: set[str] = set()
+    texts = [(schemas / name).read_text(encoding="utf-8") for name in SCHEMA_FILES]
+    for text in texts:
+        for type_name in CHARGING_SCHEMA_TYPES:
+            match = re.search(
+                SCHEMA_TYPE_RE % type_name, text, re.MULTILINE | re.DOTALL
+            )
+            if match is None:
+                continue
+            seen.add(type_name)
+            fields |= set(SCHEMA_FIELD_RE.findall(match.group(1)))
+    for root in CHARGING_SCHEMA_ROOTS:
+        if any(re.search(SCHEMA_ROOT_RE % root, text, re.MULTILINE) for text in texts):
+            seen.add(root)
+            fields.add(root)
+    missing = [
+        name
+        for name in CHARGING_SCHEMA_TYPES + CHARGING_SCHEMA_ROOTS
+        if name not in seen
+    ]
+    if missing:
+        # A renamed type or root would silently shrink the schema side and
+        # manufacture a delta against the app, which is the exact failure this
+        # whole mode is meant to make impossible.
+        raise SystemExit(
+            "charging schema names not found in either vendored schema: "
+            + ", ".join(missing)
+        )
+    return fields
+
+
+def relative_prefix(paths: Iterable[Path], root: Path) -> str:
+    """The shared directory prefix of the scanned sources, discovered not assumed.
+
+    This is what distinguishes `sources/` from `java_src/` from a root that is
+    already the source root -- read off the files that were actually found.
+    """
+    prefix: list[str] | None = None
+    for path in paths:
+        parts = list(path.relative_to(root).parts[:-1])
+        if prefix is None:
+            prefix = parts
+            continue
+        keep = 0
+        while keep < min(len(prefix), len(parts)) and prefix[keep] == parts[keep]:
+            keep += 1
+        prefix = prefix[:keep]
+        if not prefix:
+            break
+    return "/".join(prefix) if prefix else "."
+
+
+def sweep_version(version: str, root: Path, sensors: bool = False) -> dict:
+    """Walk one dump once, collecting everything the sweep needs from it.
+
+    `sensors` is off by default because it costs two more regex scans per file
+    across 26 trees, and the command ledger -- the older and more used half of
+    this script -- does not need any of it.
+    """
+    command_sources: dict[str, str] = {}
+    feature_text: str | None = None
+    document_hits: list[tuple[str, str]] = []
+    java_files: list[Path] = []
+    rvm_names: set[str] = set()
+    parallax_attributes = False
+    charging_fields: set[str] = set()
+    charging_documents = 0
+
+    for path in sorted(root.rglob("*.java")):
+        java_files.append(path)
+        name = path.name
+        wanted = name in VAS_COMMAND_FILES or name == VEHICLE_FEATURE_FILE
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as err:  # unreadable file: report, do not silently drop
+            print(f"warning: {version}: cannot read {path}: {err}", file=sys.stderr)
+            continue
+        if name in VAS_COMMAND_FILES:
+            command_sources[name] = text
+        elif name == VEHICLE_FEATURE_FILE:
+            feature_text = text
+        if not wanted and VEHICLE_STATE_MARKER.search(text):
+            document_hits.append((str(path.relative_to(root)), text))
+        if not sensors:
+            continue
+        if name == PARALLAX_ATTRIBUTES_FILE:
+            parallax_attributes = True
+        rvm_names |= extract_rvm_names(text)
+        if CHARGING_ROOT_RE.search(text):
+            for match in JAVA_STRING_RE.finditer(text):
+                found = charging_field_names(unescape_java(match.group(1)))
+                if found:
+                    charging_documents += 1
+                    charging_fields |= found
+
+    commands = extract_commands(command_sources)
+    documents = extract_documents(document_hits)
+    features = extract_features(feature_text) if feature_text else []
+
+    errors: list[str] = []
+    if not java_files:
+        errors.append("no .java files found under the dump root")
+    if not command_sources:
+        errors.append("no VASCommand sources found")
+    if not commands:
+        errors.append("zero commands extracted")
+
+    result = {
+        "version": version,
+        "root": str(root),
+        "layout": relative_prefix(java_files, root),
+        "files_scanned": len(java_files),
+        "commands": commands,
+        "documents": documents,
+        "features": features,
+        "errors": errors,
+    }
+    if sensors:
+        # The vehicleState half re-reads the documents already collected above,
+        # under the depth-1 metric rather than the tokenizer's.
+        vehicle_state_fields: set[str] = set()
+        for _, text in document_hits:
+            for match in JAVA_STRING_RE.finditer(text):
+                body = unescape_java(match.group(1))
+                if VEHICLE_STATE_MARKER.search(body):
+                    vehicle_state_fields |= vehicle_state_field_names(body)
+        result["sensors"] = {
+            "vehicle_state_fields": sorted(vehicle_state_fields),
+            "rvm_names": sorted(rvm_names),
+            "parallax_attributes": parallax_attributes,
+            "feature_pairs": [(f["member"], f["feature_name"]) for f in features],
+            "charging_fields": sorted(charging_fields),
+            "charging_documents": charging_documents,
+        }
+    return result
+
+
+def report(result: dict) -> None:
+    status = "ERROR" if result["errors"] else "ok"
+    cloud = sum(1 for c in result["commands"] if c["cloud"])
+    ble = sum(1 for c in result["commands"] if c["ble"])
+    invalid = sum(1 for c in result["commands"] if c["cloud_invalid"])
+    print(f"=== {result['version']}  [{status}]")
+    print(f"  root     {result['root']}")
+    print(f"  layout   {result['layout']}  ({result['files_scanned']} .java files)")
+    print(
+        f"  commands {len(result['commands'])}"
+        f"  (cloud {cloud}, ble {ble}, invalid-cloud {invalid})"
+    )
+    for command in result["commands"]:
+        wrappers = ",".join(
+            [
+                w
+                for w, on in (
+                    ("cloud", command["cloud"]),
+                    ("ble", command["ble"]),
+                    ("invalid-cloud", command["cloud_invalid"]),
+                )
+                if on
+            ]
+        )
+        print(f"    {command['name']:48s} {wrappers or '-':20s} {command['class']}")
+    print(f"  documents {len(result['documents'])}")
+    for document in result["documents"]:
+        for operation in document["operations"]:
+            label = operation["operation"] or "(unnamed)"
+            print(
+                f"    {document['file']}  {operation['type'] or '?'} {label}"
+                f"  ({len(operation['fields'])} fields)"
+            )
+            print(f"      {' '.join(operation['fields'])}")
+    print(f"  features {len(result['features'])}")
+    for feature in result["features"]:
+        marker = " *" if feature["member"] != feature["feature_name"] else "  "
+        print(f"   {marker} {feature['member']:44s} {feature['feature_name']}")
+    for error in result["errors"]:
+        print(f"  ERROR: {error}")
+    print()
+
+
+# Layout is a PROXY for the producing pipeline, not the pipeline itself. Which
+# decompiler wrote each 1.x/2.x dump was never recorded, and that gap is why a
+# count is only comparable within a cohort: a drop between versions cannot be
+# attributed to a real app change rather than a lossier extraction unless the
+# producing tool is known. Only the 3.15.0 cohort has documented provenance
+# (jadx, per docs/development/apk/REGENERATION.md).
+COHORTS: dict[str, str] = {
+    "sources": "A/sources (1.x + 2.0.0_beta; decompiler unrecorded)",
+    "java_src": "B/java_src (2.2.0+; decompiler unrecorded)",
+    ".": "C/jadx (3.15.0 build 4804; jadx, documented)",
+}
+
+
+def roll_up_ledger(results: list[dict]) -> list[dict]:
+    """One row per command name, across every version it ever appeared in.
+
+    The ledger is the deliverable; the probe queue is a prioritised view over it.
+    So a row records what the app said and when, and never whether the command is
+    worth sending -- a decompile enumerates, only the vehicle promotes.
+    """
+    ordered = sorted(results, key=lambda r: version_key(r["version"]))
+    rows: dict[str, dict] = {}
+
+    for result in ordered:
+        cohort = COHORTS.get(result["layout"], result["layout"])
+        for command in result["commands"]:
+            name = command.get("name")
+            if not name:
+                continue
+            row = rows.setdefault(
+                name,
+                {
+                    "name": name,
+                    "first_seen": result["version"],
+                    "last_seen": result["version"],
+                    "versions": [],
+                    "cohorts": [],
+                    "cloud": False,
+                    "ble": False,
+                    "cloud_invalid": False,
+                },
+            )
+            row["last_seen"] = result["version"]
+            # Deduped, like `cohorts` two lines below. Two classes in one dump can
+            # resolve to the same command name -- OPEN_LIFTGATE_UNLATCH_TAILGATE
+            # does in 25 of 26 versions -- and an unconditional append counted it
+            # twice, shipping n=51 for a 26-version corpus.
+            if result["version"] not in row["versions"]:
+                row["versions"].append(result["version"])
+            if cohort not in row["cohorts"]:
+                row["cohorts"].append(cohort)
+            for transport in ("cloud", "ble", "cloud_invalid"):
+                if command.get(transport):
+                    row[transport] = True
+
+    for row in rows.values():
+        if row["cloud"]:
+            row["transport"] = "cloud+ble" if row["ble"] else "cloud"
+        elif row["ble"]:
+            row["transport"] = "ble-only"
+        elif row["cloud_invalid"]:
+            row["transport"] = "invalid-wrapper"
+        else:
+            row["transport"] = "none"
+
+    return [rows[name] for name in sorted(rows)]
+
+
+# --- sensor-surface roll-up --------------------------------------------------
+
+# The FLOOR is the union size measured across the whole corpus on 2026-08-31. It
+# exists for the same reason the command ledger's does: an extractor that quietly
+# stops matching -- a renamed obfuscated class, a jadx output change, a dump that
+# moved -- reports a SMALLER union and every delta gets smaller with it, which
+# reads like progress. A shrink is therefore an error, not a pass. A GROWTH is
+# fine and is reported, because a new app build legitimately adds names.
+#
+# Each floor is per-surface because the four surfaces fail independently: the
+# Parallax table can vanish while the vehicleState documents parse perfectly.
+SURFACE_FLOORS: dict[str, int] = {
+    "vehicle_state": 157,
+    "parallax_rvm": 58,
+    "vehicle_feature": 89,
+    "charging": 52,
+}
+
+SURFACE_TITLES: dict[str, str] = {
+    "vehicle_state": "vehicleState GraphQL fields  vs  VEHICLE_STATE_API_FIELDS",
+    "parallax_rvm": "Parallax RVMs  vs  RVM_DECODERS",
+    "vehicle_feature": "VehicleFeature (member, featureName)  vs  VEHICLE_FEATURES",
+    "charging": "charging / wallbox fields  vs  the vendored schemas",
+}
+
+SURFACE_METRICS: dict[str, str] = {
+    "vehicle_state": (
+        "depth-1 names on VehicleState, fragment spreads resolved -- the metric "
+        "of scripts/gates/helpers/apk_vehicle_state_fields.py, NOT "
+        "graphql_field_names()"
+    ),
+    "parallax_rvm": (
+        "rvmName literals of the obfuscated enum tables; 3.x ONLY -- "
+        "ParallaxAttributes.java is absent from every 1.x and 2.x tree, so the "
+        "historical corpus contributes nothing to this surface"
+    ),
+    "vehicle_feature": (
+        "both columns: the member the app branches on and the featureName the "
+        "server emits; they differ for 19 of the 64 members in 3.15.0"
+    ),
+    "charging": (
+        "field names at any depth in the operations the integration itself "
+        "sends; the schema side spans gateway.graphql AND charging.graphql, "
+        "because WallboxRecord lives in the latter"
+    ),
+}
+
+
+def sensor_surfaces(
+    results: list[dict], repo_root: Path, enforce_floor: bool = True
+) -> dict:
+    """The four deltas, each against the integration set it is comparable to."""
+    ordered = sorted(results, key=lambda r: version_key(r["version"]))
+
+    app: dict[str, set] = {key: set() for key in SURFACE_FLOORS}
+    seen: dict[str, dict] = {key: {} for key in SURFACE_FLOORS}
+    per_version: dict[str, list[tuple[str, int]]] = {key: [] for key in SURFACE_FLOORS}
+    parallax_versions: list[str] = []
+
+    for result in ordered:
+        sensors = result.get("sensors")
+        if sensors is None:
+            continue
+        version = result["version"]
+        contributions = {
+            "vehicle_state": set(sensors["vehicle_state_fields"]),
+            "parallax_rvm": set(sensors["rvm_names"]),
+            "vehicle_feature": {tuple(pair) for pair in sensors["feature_pairs"]},
+            "charging": set(sensors["charging_fields"]),
+        }
+        for key, names in contributions.items():
+            app[key] |= names
+            per_version[key].append((version, len(names)))
+            for name in names:
+                # first/last seen, exactly as the command ledger records them.
+                # Without this a name last present in 1.4.1 reads as a live gap,
+                # and 25 of the VehicleFeature members are precisely that.
+                window = seen[key].setdefault(name, [version, version])
+                window[1] = version
+        if sensors["parallax_attributes"]:
+            parallax_versions.append(version)
+
+    ours = {
+        "vehicle_state": integration_vehicle_state_fields(repo_root),
+        "parallax_rvm": integration_rvm_names(repo_root),
+        "vehicle_feature": integration_feature_pairs(repo_root),
+        "charging": integration_charging_fields(repo_root),
+    }
+
+    surfaces = {}
+    for key, floor in SURFACE_FLOORS.items():
+        surfaces[key] = {
+            "title": SURFACE_TITLES[key],
+            "metric": SURFACE_METRICS[key],
+            "app": sorted(app[key]),
+            "ours": sorted(ours[key]),
+            "app_only": [
+                {
+                    "name": name,
+                    "first_seen": seen[key][name][0],
+                    "last_seen": seen[key][name][1],
+                }
+                for name in sorted(app[key] - ours[key])
+            ],
+            "ours_only": sorted(ours[key] - app[key]),
+            "per_version": per_version[key],
+            "floor": floor,
+            "below_floor": enforce_floor and len(app[key]) < floor,
+        }
+
+    ledger = roll_up_ledger(results)
+    ble_only = [row for row in ledger if row["transport"] == "ble-only"]
+
+    return {
+        "surfaces": surfaces,
+        "parallax_versions": parallax_versions,
+        "ble_only_commands": ble_only,
+        "floor_enforced": enforce_floor,
+        "errors": [
+            f"{key}: union {len(surfaces[key]['app'])} is below the recorded "
+            f"floor of {surfaces[key]['floor']}"
+            for key in SURFACE_FLOORS
+            if surfaces[key]["below_floor"]
+        ],
+    }
+
+
+def format_entry(entry) -> str:
+    """A surface entry as one string. VehicleFeature entries are two columns."""
+    if isinstance(entry, (tuple, list)) and len(entry) == 2:
+        return f"{entry[0]} -> {entry[1]}"
+    return str(entry)
+
+
+def report_sensors(report: dict) -> None:
+    for key, surface in report["surfaces"].items():
+        print(f"=== ({key}) {surface['title']}")
+        print(f"  metric   {surface['metric']}")
+        floor = surface["floor"] if report["floor_enforced"] else "n/a (partial)"
+        print(
+            f"  app union {len(surface['app']):4d}   floor {floor}"
+            f"   ours {len(surface['ours'])}"
+        )
+        counts = "  ".join(f"{v}:{n}" for v, n in surface["per_version"] if n)
+        print(f"  per version  {counts or '(none)'}")
+        print(f"  in the app, not in ours  {len(surface['app_only'])}")
+        for row in surface["app_only"]:
+            window = (
+                row["first_seen"]
+                if row["first_seen"] == row["last_seen"]
+                else f"{row['first_seen']}-{row['last_seen']}"
+            )
+            print(f"    + {format_entry(row['name']):58s} {window}")
+        print(f"  in ours, not in the app  {len(surface['ours_only'])}")
+        for entry in surface["ours_only"]:
+            print(f"    - {format_entry(entry)}")
+        print()
+
+    print("=== appendix: BLE-only commands (NOT a sensor surface)")
+    print(
+        "  A command the app can only send over Bluetooth is not a field the\n"
+        "  integration is failing to read, so these are excluded from every\n"
+        "  delta above rather than counted as a gap."
+    )
+    for row in report["ble_only_commands"]:
+        print(
+            f"    {row['name']:32s} {row['first_seen']:10s} -> "
+            f"{row['last_seen']:10s}  ({len(row['versions'])} version(s))"
+        )
+    if not report["ble_only_commands"]:
+        print("    (none in this sweep)")
+    print()
+
+    versions = ", ".join(report["parallax_versions"]) or "(none)"
+    print(f"Parallax-bearing builds in this sweep: {versions}")
+    for error in report["errors"]:
+        print(f"ERROR: {error}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument(
+        "--src-root",
+        type=Path,
+        default=Path.home() / "src",
+        help="directory holding the extracted app dumps (default: ~/src)",
+    )
+    parser.add_argument(
+        "--only",
+        action="append",
+        metavar="VERSION",
+        help="sweep just this version; repeatable",
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument(
+        "--ledger",
+        action="store_true",
+        help="roll the sweep up into one row per command across all versions",
+    )
+    parser.add_argument(
+        "--sensors",
+        action="store_true",
+        help="four sensor-surface deltas against the integration's own sets",
+    )
+    args = parser.parse_args()
+
+    roots: dict[str, Path] = {v: args.src_root / d for v, d in SRC_DUMPS.items()}
+    roots.update(REPO_DUMPS)
+
+    if args.only:
+        unknown = [v for v in args.only if v not in roots]
+        if unknown:
+            known = ", ".join(sorted(roots, key=version_key))
+            raise SystemExit(
+                f"unknown version(s): {', '.join(unknown)}\nknown: {known}"
+            )
+        roots = {v: roots[v] for v in args.only}
+
+    versions = sorted(roots, key=version_key)
+
+    missing = [(v, roots[v]) for v in versions if not roots[v].is_dir()]
+    if missing:
+        for version, root in missing:
+            print(
+                f"ERROR: {version}: dump directory not found: {root}", file=sys.stderr
+            )
+        print(
+            "The corpus is an explicit allowlist, so a missing directory means the "
+            "dump was moved or never extracted -- it is not skipped.",
+            file=sys.stderr,
+        )
+        return 2
+
+    results = [
+        sweep_version(version, roots[version], sensors=args.sensors)
+        for version in versions
+    ]
+
+    if args.sensors:
+        # A partial sweep cannot meet a whole-corpus floor, so `--only`
+        # reports the deltas and skips the floor rather than failing.
+        surfaces = sensor_surfaces(results, REPO_ROOT, enforce_floor=not args.only)
+        if args.json:
+            print(json.dumps(surfaces, indent=2))
+        else:
+            report_sensors(surfaces)
+        failed = any(r["errors"] for r in results) or surfaces["errors"]
+        return 1 if failed else 0
+
+    if args.ledger:
+        ledger = roll_up_ledger(results)
+        if args.json:
+            print(json.dumps(ledger, indent=2))
+        else:
+            print(f"{len(ledger)} command(s) across {len(results)} version(s)\n")
+            print(f"{'command':46s} {'first':10s} {'last':10s} {'n':>3s}  transport")
+            for row in ledger:
+                print(
+                    f"{row['name']:46s} {row['first_seen']:10s} "
+                    f"{row['last_seen']:10s} {len(row['versions']):>3d}  "
+                    f"{row['transport']}"
+                )
+        return 1 if any(r["errors"] for r in results) else 0
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        for result in results:
+            report(result)
+        failed = [r["version"] for r in results if r["errors"]]
+        print(f"{len(results)} version(s) swept, {len(failed)} with errors")
+        if failed:
+            print(f"errors in: {', '.join(failed)}")
+
+    return 1 if any(r["errors"] for r in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gates/s17.sh
+++ b/scripts/gates/s17.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# S17 — the corpus extractor works on all THREE tree layouts, not the two it was
+# tested against.
+#
+# WHY THIS GATE EXISTS. `scripts/apk_corpus_sweep.py` reads decompiled app dumps
+# spanning 26 versions. Those dumps do not share a root layout:
+#
+#   sources/        all 1.x dumps AND rivian_2.0.0_beta   (19 of 25)
+#   java_src/       2.2.0 and later                        (6 of 25)
+#   jadx/sources/   the in-repo 3.15.0 tree
+#
+# The plan that commissioned the extractor proposed testing it against two trees
+# -- 2.6.0 (java_src) and 3.15.0 (jadx/sources). Both of those happen to hold
+# VASCommand.java under com/rivian/android/core/modules/, so a two-tree gate
+# passes whether or not the extractor hard-codes that package path, and it never
+# touches the `sources/` layout that the MAJORITY of the corpus uses. A gate that
+# cannot distinguish a correct extractor from one that breaks on 19 of 25 dumps
+# is not a gate. Hence three layouts here, one spot check each.
+#
+# The spot check is the point. Asserting "nonzero commands" catches a total
+# failure and misses a PARTIAL -- an extractor reading the wrong subtree still
+# returns something. Each layout therefore names a command that must be present.
+#
+# INDEPENDENCE. This gate does NOT run apk_corpus_sweep.py. `scripts/gates/f1.sh`
+# states the rule it inherits: "A gate that re-runs the generator proves only that
+# the generator is deterministic." The derivation below is a flat grep for the
+# command-name string literal -- deliberately a different mechanism from the
+# extractor's class-block parser, so the two can disagree.
+#
+# The dumps are gitignored and live outside the repo, so this is a pre-flight
+# gate, not a test. A clean checkout has no corpus; a skipped test would be worse
+# than an absent one, which is why this half lives here.
+
+source "$(dirname "$0")/_lib.sh"
+
+echo "s17 — corpus extractor across all three tree layouts"
+
+SRC_ROOT="${APK_SRC_ROOT:-$HOME/src}"
+SWEEP="$HA/scripts/apk_corpus_sweep.py"
+
+have_path "the extractor exists" "$SWEEP"
+
+# --- 1. the extractor enumerates, and does not glob -------------------------
+#
+# `~/src/rivian*` also matches rivian-dump/, which is ABRP telemetry JSON and not
+# an app dump at all. An allowlist is the only enumeration that excludes it.
+contains "the corpus is an explicit allowlist" "SRC_DUMPS" "$SWEEP"
+
+if grep -qE 'glob\(["'"'"']rivian' "$SWEEP"; then
+  bad "the extractor globs for dump directories"
+else
+  ok "the extractor does not glob for dump directories"
+fi
+
+# --- 2. one dump per layout, each with a spot check -------------------------
+#
+# layout|dir|command that must be present
+LAYOUTS="
+sources|rivian_1.0.3|WAKE_VEHICLE
+java_src|com_rivian_android_consumer_v2.6.0|UNLOCK_ALL_AND_OPEN_WINDOWS
+"
+
+while IFS='|' read -r layout dir command; do
+  [ -z "$layout" ] && continue
+  root="$SRC_ROOT/$dir"
+
+  # A missing dump FAILS. Skipping it silently is how a gate reports green on a
+  # machine where pre-flight never ran.
+  if [ ! -d "$root" ]; then
+    bad "$layout: dump present ($dir)"
+    note "expected at: $root"
+    note "run pre-flight, or set APK_SRC_ROOT to where the dumps live"
+    continue
+  fi
+  ok "$layout: dump present ($dir)"
+
+  # The layout is what this gate is about, so assert it rather than assuming it.
+  if [ -d "$root/$layout" ]; then
+    ok "$layout: layout confirmed on disk"
+  else
+    bad "$layout: expected a $layout/ subtree in $dir"
+  fi
+
+  # Independent re-derivation: a flat grep for the string literal, restricted to
+  # .java. Without --include a .dex under resources/ matches the same bytes --
+  # that exact mistake produced a wrong document count earlier in this work.
+  hits=$( { grep -rl -I --include='*.java' -- "\"$command\"" "$root" || true; } \
+            | wc -l | tr -d ' ')
+  if [ "$hits" -gt 0 ]; then
+    ok "$layout: $command found independently ($hits files)"
+  else
+    bad "$layout: $command NOT found in $dir"
+  fi
+done <<EOF
+$LAYOUTS
+EOF
+
+# --- 3. the third layout: the in-repo 3.15.0 tree ---------------------------
+#
+# Separate from the loop because its root is repo-relative and its spot check is
+# a capability member rather than a command: 3.15.0's VASCommand.java carries no
+# BLE wrappers at all, so command coverage there is not comparable to the others.
+JADX="$HA/.apk/3.15.0/jadx/sources"
+
+if [ ! -d "$JADX" ]; then
+  bad "jadx/sources: the 3.15.0 tree is present"
+  note "expected at: $JADX"
+  note "REGENERATION.md records how to rebuild it"
+else
+  ok "jadx/sources: the 3.15.0 tree is present"
+
+  vf=$( { grep -rl -I --include='VehicleFeature.java' -- 'TAILGATE_CMD' "$JADX" \
+            || true; } | wc -l | tr -d ' ')
+  if [ "$vf" -gt 0 ]; then
+    ok "jadx/sources: VehicleFeature found independently"
+  else
+    bad "jadx/sources: VehicleFeature NOT found"
+  fi
+fi
+
+# --- 4. the gitignore that keeps proprietary source out of a public repo ----
+if git -C "$HA" check-ignore -q .apk/3.15.0; then
+  ok "the decompiled tree is gitignored"
+else
+  bad "the decompiled tree is NOT gitignored -- this is a public HACS repo"
+fi
+
+summary S17

--- a/scripts/probe_field_names.py
+++ b/scripts/probe_field_names.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Ask the gateway whether it knows a `vehicleState` field name. One at a time.
+
+READ-ONLY. This opens subscriptions and reads what comes back. It sends no
+vehicle command and actuates nothing.
+
+Why one at a time, and why a scratch document: the server rejects the ENTIRE
+document if a single field name is unknown, so a probe carrying several
+candidates cannot tell "all fine" from "one bad name killed it" -- the failure
+`scripts/f8_probe.py` exists to bisect around. Here each candidate rides alone
+with two known-good control fields, so a rejection names its own culprit and no
+bisection is needed.
+
+The candidates must NOT be added to `VEHICLE_STATE_API_FIELDS` first. Doing that
+puts an unproven name into the document the integration actually sends, where a
+rejection takes out every sensor at once rather than one probe.
+
+Three outcomes, and they are not the same thing:
+
+    ACCEPTED + delivered   the gateway knows the name and has a value for it
+    ACCEPTED + silent      the gateway knows the name and sent nothing. That is
+                           SILENCE, NOT FAILURE -- see UNPOPULATED_FIELDS.md. It
+                           is a recorded finding, never grounds for deleting a
+                           sensor
+    REJECTED               the gateway does not know the name in this document
+
+A decompile never promotes a row; only a live accept does. That rule is why this
+script exists at all -- `docs/development/APK_HISTORICAL_SWEEP.md` found these
+names in the app, which is a reason to probe them and not a reason to ship them.
+
+Secrets: reads tokens from `.env` and prints none of them.
+
+Requires the repo venv (`aiohttp`, and the client imports homeassistant).
+
+Usage:
+    .venv/bin/python scripts/probe_field_names.py --dry-run
+    .venv/bin/python scripts/probe_field_names.py passiveEntryUnlockFailReason
+    .venv/bin/python scripts/probe_field_names.py            # all defaults
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import aiohttp
+from f8_probe import CONTROL, attempt, load_env
+
+from custom_components.rivian.rivian_client import Rivian
+
+# Found in 3.15.0's compiled documents and absent from ours -- see
+# docs/development/APK_HISTORICAL_SWEEP.md. Being in the CURRENT build is what
+# makes these worth the gateway's time; the historical-only names are not here.
+DEFAULT_CANDIDATES = (
+    "passiveEntryUnlockFailReason",
+    "vasAccessCanFaulted",
+    "vasSecureElementFaulted",
+)
+
+
+def _dry_run(candidates: tuple[str, ...]) -> int:
+    """Print what would be sent, without connecting."""
+    print(f"control fields: {CONTROL}")
+    for candidate in candidates:
+        print(f"  scratch document for {candidate}: {[*CONTROL, candidate]}")
+    print("\nno network calls made")
+    return 0
+
+
+async def run(candidates: tuple[str, ...]) -> int:
+    env = load_env()
+    async with aiohttp.ClientSession() as session:
+        client = Rivian(
+            session=session,
+            access_token=env["RIVIAN_ACCESS_TOKEN"],
+            refresh_token=env["RIVIAN_REFRESH_TOKEN"],
+            user_session_token=env["RIVIAN_USER_SESSION_TOKEN"],
+        )
+        payload = await (await client.get_user_information(True)).json()
+        vehicle_id = payload["data"]["currentUser"]["vehicles"][0]["id"]
+
+        # The control proves the instrument before any candidate is judged by it.
+        # Without this, a broken session reads as "every name rejected".
+        print(f"=== CONTROL {CONTROL} ===")
+        accepted, _, delivered = await attempt(client, vehicle_id, CONTROL, "control")
+        if not accepted or not delivered:
+            print("CONTROL FAILED -- the probe is not a valid instrument now. STOP.")
+            return 2
+        print("control accepted\n")
+
+        results: dict[str, str] = {}
+        for candidate in candidates:
+            print(f"=== {candidate} ===")
+            accepted, _, got = await attempt(
+                client, vehicle_id, [*CONTROL, candidate], candidate
+            )
+            if not accepted:
+                results[candidate] = "REJECTED"
+            elif candidate in got:
+                results[candidate] = "ACCEPTED, delivered"
+            else:
+                results[candidate] = "ACCEPTED, silent"
+            print(f"  -> {results[candidate]}\n")
+
+        print("=== summary ===")
+        for candidate, verdict in results.items():
+            print(f"  {candidate:34s} {verdict}")
+        print(
+            "\nACCEPTED+silent is silence, not failure. Record every result in "
+            "docs/development/COMMAND_COVERAGE.md before acting on it."
+        )
+        return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument(
+        "candidates",
+        nargs="*",
+        default=list(DEFAULT_CANDIDATES),
+        help="field names to probe (default: the three from the corpus sweep)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the scratch documents without connecting",
+    )
+    args = parser.parse_args()
+    names = tuple(args.candidates) or DEFAULT_CANDIDATES
+    if args.dry_run:
+        raise SystemExit(_dry_run(names))
+    raise SystemExit(asyncio.run(run(names)))

--- a/tests/test_apk_corpus_sweep.py
+++ b/tests/test_apk_corpus_sweep.py
@@ -100,9 +100,24 @@ class TestCorpusAllowlist:
         assert "rivian-dump" not in sweep.SRC_DUMPS.values()
 
     def test_every_on_disk_dump_version_is_listed(self) -> None:
-        """25 `~/src` dumps; 3.15.0 lives in the repo and is tracked separately."""
+        """25 `~/src` dumps plus the trees under `.apk/`, 54 versions in all.
+
+        The `.apk/` trees were all decompiled here with jadx 1.5.6 from APKMirror
+        bundles, so unlike cohorts A and B -- whose decompiler was never recorded
+        -- that cohort has documented provenance and its counts are comparable to
+        each other. 3.15.0 stays its ground truth; 3.16.0 is the frontier build,
+        and Google Play serves only current, so nothing can be backfilled from it.
+        """
         assert len(sweep.SRC_DUMPS) == 25
-        assert "3.15.0" in sweep.REPO_DUMPS
+        assert len(sweep.REPO_DUMPS) == 29
+        assert {"3.15.0", "3.16.0"} <= set(sweep.REPO_DUMPS)
+
+    def test_the_repo_trees_all_share_one_layout(self) -> None:
+        """Their root IS jadx/sources, so every one resolves to the `.` cohort."""
+        assert all(
+            path.name == "sources" and path.parent.name == "jadx"
+            for path in sweep.REPO_DUMPS.values()
+        )
 
 
 class TestVehicleStateDepthOneMetric:
@@ -352,7 +367,7 @@ class TestShippedLedgerIsGuarded:
     of which ship, so they run in a clean checkout with no corpus present.
     """
 
-    CORPUS_SIZE = 26
+    CORPUS_SIZE = 54  # 25 in ~/src, plus 29 decompiled trees in .apk/
     LEDGER = (
         pathlib.Path(__file__).resolve().parents[1]
         / "docs"

--- a/tests/test_apk_corpus_sweep.py
+++ b/tests/test_apk_corpus_sweep.py
@@ -1,0 +1,469 @@
+"""Unit tests for the cross-version APK extractor.
+
+These test the extractor's LOGIC, never a decompiled tree. The dumps are
+gitignored and live outside the repo, so a test that read one could not run in a
+clean checkout -- and a skipped test is worse than an absent one. The
+tree-reading half belongs in `scripts/gates/`, exactly as
+`tests/test_apk_transcription.py` and `scripts/gates/f1.sh` already divide it.
+
+The `wiperFluidState` case below is the one that earned its own test. That name
+is a real `vehicleState` field AND a prefix of the Room column
+`wiperFluidStateUpdatedTimestamp`, so a substring match counts 14 where a
+whole-word match counts 15. `docs/development/apk/REGENERATION.md` records that
+discrepancy, and four earlier flat greps of this app were lossy -- which is why
+the shipped data is transcribed rather than grepped. An extractor that
+reintroduces substring matching would be the fifth.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import pathlib
+import re
+
+import pytest
+
+_MODULE_PATH = (
+    pathlib.Path(__file__).resolve().parents[1] / "scripts" / "apk_corpus_sweep.py"
+)
+_SPEC = importlib.util.spec_from_file_location("apk_corpus_sweep", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+sweep = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(sweep)
+
+
+class TestWholeWordFieldNames:
+    """`wiperFluidState` must not be conflated with its longer neighbour."""
+
+    def test_both_names_survive_as_distinct_fields(self) -> None:
+        """A document carrying both yields both, and the short one exactly once."""
+        document = """
+        query GetVehicleState {
+          vehicleState(id: $id) {
+            wiperFluidState { value }
+            wiperFluidStateUpdatedTimestamp { value }
+          }
+        }
+        """
+        fields = sweep.graphql_field_names(document)
+
+        assert fields.count("wiperFluidState") == 1
+        assert "wiperFluidStateUpdatedTimestamp" in fields
+
+    def test_the_room_column_alone_does_not_yield_the_short_name(self) -> None:
+        """The substring is present; the field is not. Only whole-word sees that."""
+        document = """
+        query GetVehicleState {
+          vehicleState(id: $id) {
+            wiperFluidStateUpdatedTimestamp { value }
+          }
+        }
+        """
+        fields = sweep.graphql_field_names(document)
+
+        assert "wiperFluidStateUpdatedTimestamp" in fields
+        assert "wiperFluidState" not in fields
+
+
+class TestVersionOrdering:
+    """Provenance strings are only useful if versions sort like versions."""
+
+    def test_ten_sorts_after_nine(self) -> None:
+        """String sorting puts 1.10.0 before 1.9.0. Numeric sorting does not."""
+        ordered = sorted(["1.10.0", "1.9.0", "1.2.1"], key=sweep.version_key)
+
+        assert ordered == ["1.2.1", "1.9.0", "1.10.0"]
+
+    @pytest.mark.parametrize("version", ["2.0.0_beta", "2.5.0_beta"])
+    def test_the_beta_spellings_parse(self, version: str) -> None:
+        """Both betas are irregular on disk and neither may crash the sort."""
+        assert sweep.version_key(version)
+
+    def test_a_beta_sorts_before_its_release(self) -> None:
+        """2.0.0_beta precedes 2.2.0; the tiebreak must not invert them."""
+        ordered = sorted(["2.2.0", "2.0.0_beta"], key=sweep.version_key)
+
+        assert ordered == ["2.0.0_beta", "2.2.0"]
+
+
+class TestCorpusAllowlist:
+    """The corpus is enumerated, never globbed."""
+
+    def test_the_irregular_directory_names_are_carried_verbatim(self) -> None:
+        """One has an underscore, one a SPACE. Normalising either loses the dump."""
+        assert sweep.SRC_DUMPS["2.0.0_beta"] == "rivian_2.0.0_beta"
+        assert sweep.SRC_DUMPS["2.5.0_beta"] == "rivian_2.5.0 beta"
+
+    def test_the_allowlist_excludes_the_abrp_telemetry_directory(self) -> None:
+        """`~/src/rivian-dump/` matches a `rivian*` glob and is not an app dump."""
+        assert "rivian-dump" not in sweep.SRC_DUMPS.values()
+
+    def test_every_on_disk_dump_version_is_listed(self) -> None:
+        """25 `~/src` dumps; 3.15.0 lives in the repo and is tracked separately."""
+        assert len(sweep.SRC_DUMPS) == 25
+        assert "3.15.0" in sweep.REPO_DUMPS
+
+
+class TestVehicleStateDepthOneMetric:
+    """The sensor mode measures depth 1, not every depth. The two disagree."""
+
+    DOCUMENT = """subscription VehicleState($vehicleID: String!) {
+      vehicleState(id: $vehicleID) {
+        __typename
+        batteryLevel { timeStamp value }
+        gnssLocation { latitude longitude }
+        ...VehicleStateFields
+      }
+    }
+    fragment VehicleStateFields on VehicleState {
+      powerState { timeStamp value }
+    }
+    """
+
+    def test_nested_names_are_not_counted_as_subscribed_fields(self) -> None:
+        """`latitude` is inside `gnssLocation`, so it is not a subscribed name.
+
+        `VEHICLE_STATE_API_FIELDS` is a set of TOP-LEVEL names. Counting nested
+        ones inflates the app side and manufactures a deficit that is not real.
+        """
+        fields = sweep.vehicle_state_field_names(self.DOCUMENT)
+
+        assert "gnssLocation" in fields
+        assert "latitude" not in fields
+        assert "value" not in fields
+
+    def test_a_fragment_spread_contributes_its_own_depth_one_names(self) -> None:
+        """Not resolving spreads drops whole documents -- h9l and lel yield 0."""
+        fields = sweep.vehicle_state_field_names(self.DOCUMENT)
+
+        assert "powerState" in fields
+
+    def test_the_two_metrics_diverge_and_that_is_the_point(self) -> None:
+        """The tokenizer counts more. Neither is wrong; only one is comparable."""
+        depth_one = sweep.vehicle_state_field_names(self.DOCUMENT)
+        any_depth = set(sweep.graphql_field_names(self.DOCUMENT))
+
+        assert depth_one < any_depth
+
+    def test_typename_is_not_a_field(self) -> None:
+        """Apollo bookkeeping, and subscribing to it would be a name we invented."""
+        assert "__typename" not in sweep.vehicle_state_field_names(self.DOCUMENT)
+
+
+class TestRvmTableExtraction:
+    """The enum class name is obfuscated and build-specific; the property is not."""
+
+    def test_the_restored_enum_form_yields_its_rvm_names(self) -> None:
+        """jadx emits `NAME("rvm.name"),` when it can restore the enum modifier."""
+        source = """public enum iol {
+            USER_PASSCODES_DRIVE_AUTH("user_passcodes.passcode_types.drive_auth"),
+            PASSIVE_ENTRY_SETTING_V2("security.access.passive_entry");
+            private final String rvmName;
+        }"""
+
+        assert sweep.extract_rvm_names(source) == {
+            "user_passcodes.passcode_types.drive_auth",
+            "security.access.passive_entry",
+        }
+
+    def test_the_unrestored_enum_form_yields_them_too(self) -> None:
+        """When it cannot, it emits constructor calls -- 3.15.0's real l6e.java."""
+        source = """public final class l6e {
+            private final String rvmName;
+            public static final l6e BODY_LOCKS_STATES =
+                new l6e("BODY_LOCKS_STATES", 21, "body.locks.states", true, null);
+        }"""
+
+        assert sweep.extract_rvm_names(source) == {"body.locks.states"}
+
+    def test_a_file_without_the_marker_yields_nothing(self) -> None:
+        """Dotted lowercase literals are everywhere. Only the RVM table counts."""
+        source = """public final class Analytics {
+            static final String EVENT = "body.locks.states";
+        }"""
+
+        assert sweep.extract_rvm_names(source) == set()
+
+
+class TestChargingSurfaceScoping:
+    """The charging surface is the operations the INTEGRATION sends, not all of them."""
+
+    def test_a_wallbox_query_yields_its_fields(self) -> None:
+        document = (
+            "query getRegisteredWallboxes { getRegisteredWallboxes "
+            "{ wallboxId chargingStatus maxAmps } }"
+        )
+
+        assert sweep.charging_field_names(document) >= {
+            "wallboxId",
+            "chargingStatus",
+            "maxAmps",
+        }
+
+    def test_an_unrelated_operation_yields_nothing(self) -> None:
+        """Charging-network browsing is not a surface this integration implements."""
+        document = "query chargingSites { chargingSites { id name } }"
+
+        assert sweep.charging_field_names(document) == set()
+
+    def test_a_string_that_is_not_an_operation_yields_nothing(self) -> None:
+        """Every Java string literal is offered to this; most are not GraphQL."""
+        assert sweep.charging_field_names("failed to load getWallboxStatus") == set()
+
+
+class TestIntegrationSetsAreParsedNotImported:
+    """`const.py` cannot be imported without Home Assistant. It is parsed."""
+
+    def test_union_and_difference_both_evaluate(self) -> None:
+        """`VEHICLE_STATE_API_FIELDS` is built from `|` and `-` over four names."""
+        module = ast.parse(
+            "A = frozenset({'a', 'b'})\n"
+            "B: Final[frozenset[str]] = frozenset({'c'})\n"
+            "C = {'b'}\n"
+            "D = (A | B) - C\n"
+        )
+        env: dict[str, set[str]] = {}
+        for statement in module.body:
+            target = (
+                statement.target
+                if isinstance(statement, ast.AnnAssign)
+                else statement.targets[0]
+            )
+            resolved = sweep._eval_set_expr(statement.value, env)
+            if resolved is not None:
+                env[target.id] = resolved
+
+        assert env["D"] == {"a", "c"}
+
+    def test_an_expression_it_cannot_evaluate_is_skipped_not_guessed(self) -> None:
+        """A silent wrong answer here would move every delta by an unknown amount."""
+        node = ast.parse("X = sorted(other)").body[0].value
+
+        assert sweep._eval_set_expr(node, {}) is None
+
+    def test_the_real_symbols_all_resolve(self) -> None:
+        """A rename in the integration must fail loudly here, not shrink a delta."""
+        root = sweep.REPO_ROOT
+
+        assert len(sweep.integration_vehicle_state_fields(root)) == 149
+        assert len(sweep.integration_rvm_names(root)) == 33
+        assert len(sweep.integration_feature_pairs(root)) == 64
+        assert sweep.integration_charging_fields(root)
+
+
+def _result(version: str, sensors: dict, commands: list | None = None) -> dict:
+    return {
+        "version": version,
+        "layout": ".",
+        "commands": commands or [],
+        "errors": [],
+        "sensors": sensors,
+    }
+
+
+_EMPTY_SENSORS = {
+    "vehicle_state_fields": [],
+    "rvm_names": [],
+    "parallax_attributes": False,
+    "feature_pairs": [],
+    "charging_fields": [],
+    "charging_documents": 0,
+}
+
+
+class TestSurfaceFloors:
+    """A shrinking union reads like progress. It is the extractor breaking."""
+
+    def test_a_union_below_the_floor_is_an_error_on_every_surface(self) -> None:
+        """Four floors, not one: the four surfaces fail independently."""
+        report = sweep.sensor_surfaces(
+            [_result("3.15.0", _EMPTY_SENSORS)], sweep.REPO_ROOT
+        )
+
+        assert len(report["errors"]) == len(sweep.SURFACE_FLOORS)
+        assert all(s["below_floor"] for s in report["surfaces"].values())
+
+    def test_a_partial_sweep_reports_the_delta_without_claiming_the_floor(self) -> None:
+        """`--only 3.15.0` cannot meet a whole-corpus floor and must not pretend to."""
+        report = sweep.sensor_surfaces(
+            [_result("3.15.0", _EMPTY_SENSORS)], sweep.REPO_ROOT, enforce_floor=False
+        )
+
+        assert report["errors"] == []
+        assert report["floor_enforced"] is False
+
+    def test_every_surface_carries_a_nonzero_floor(self) -> None:
+        """A floor of zero is not a floor; it is an assertion that never fires."""
+        assert set(sweep.SURFACE_FLOORS) == set(sweep.SURFACE_TITLES)
+        assert all(floor > 0 for floor in sweep.SURFACE_FLOORS.values())
+
+
+class TestBleOnlyCommandsAreAnAppendix:
+    """A BLE-only command is not a field the integration failed to read."""
+
+    def test_it_lands_in_the_appendix_and_in_no_surface(self) -> None:
+        """WINCH_IN is BLE-only across 1.0.3-1.4.1 and belongs nowhere else."""
+        command = {
+            "name": "WINCH_IN",
+            "class": "WinchIn",
+            "cloud": False,
+            "ble": True,
+            "cloud_invalid": False,
+        }
+        report = sweep.sensor_surfaces(
+            [_result("1.0.3", _EMPTY_SENSORS, [command])],
+            sweep.REPO_ROOT,
+            enforce_floor=False,
+        )
+
+        assert [row["name"] for row in report["ble_only_commands"]] == ["WINCH_IN"]
+        for surface in report["surfaces"].values():
+            assert "WINCH_IN" not in surface["app"]
+
+    def test_a_cloud_command_is_not_in_the_appendix(self) -> None:
+        """The appendix is BLE-ONLY; a cloud-sendable command is a different thing."""
+        command = {
+            "name": "WAKE_VEHICLE",
+            "class": "WakeVehicle",
+            "cloud": True,
+            "ble": True,
+            "cloud_invalid": False,
+        }
+        report = sweep.sensor_surfaces(
+            [_result("1.0.3", _EMPTY_SENSORS, [command])],
+            sweep.REPO_ROOT,
+            enforce_floor=False,
+        )
+
+        assert report["ble_only_commands"] == []
+
+
+class TestShippedLedgerIsGuarded:
+    """The shipped ledger, not the extractor that produced it.
+
+    `scripts/gates/s17.sh` checks that the extractor works across all three tree
+    layouts. Nothing checked the artifact it emits -- which is how a row shipped
+    claiming 51 version-observations in a 26-version corpus. `roll_up_ledger`
+    appended to `versions` unconditionally while deduping `cohorts` two lines
+    below, so a command resolved by two classes in one dump counted twice.
+
+    These read only `docs/development/APK_HISTORICAL_SWEEP.md` and the enum, both
+    of which ship, so they run in a clean checkout with no corpus present.
+    """
+
+    CORPUS_SIZE = 26
+    LEDGER = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "docs"
+        / "development"
+        / "APK_HISTORICAL_SWEEP.md"
+    )
+    ROW = re.compile(
+        r"^\|\s*`(?P<name>[A-Z][A-Z0-9_]*)`(?P<mark>[^|]*)\|"
+        r"(?P<span>[^|]*)\|\s*(?P<n>\d+)\s*\|"
+    )
+
+    @classmethod
+    def _rows(cls) -> dict[str, int]:
+        """Command name -> version count, from the ledger's own table."""
+        rows: dict[str, int] = {}
+        for line in cls.LEDGER.read_text().splitlines():
+            match = cls.ROW.match(line)
+            if match:
+                rows.setdefault(match.group("name"), int(match.group("n")))
+        return rows
+
+    def test_the_ledger_ships(self) -> None:
+        """It is the deliverable; an absent one is not a passing state."""
+        assert self.LEDGER.is_file()
+
+    def test_no_row_claims_more_versions_than_the_corpus_holds(self) -> None:
+        """26 dumps cannot yield 51 observations of one command.
+
+        The check is deliberately one-sided. An OVERcount is impossible on its
+        face and needs no corpus to refute; an UNDERcount is not, and catching it
+        would mean re-extracting -- which would make this corpus-dependent and so
+        skippable, the very thing that keeps the tree-reading half in
+        `scripts/gates/`. The asymmetry is the price of a check that always runs.
+        """
+        overcounted = {
+            name: n for name, n in self._rows().items() if n > self.CORPUS_SIZE
+        }
+
+        assert not overcounted, (
+            f"rows claiming impossible version counts: {overcounted}"
+        )
+
+    def test_the_enum_only_residue_is_exactly_the_two_third_row_seat_heats(
+        self,
+    ) -> None:
+        """US-004's amended criterion, asserted rather than eyeballed.
+
+        A strict superset is impossible: the app is a lower bound, never the
+        schema. What IS checkable is the size and identity of the residue, and
+        it must not drift silently.
+        """
+        from custom_components.rivian.rivian_client import VehicleCommand
+
+        ours = {command.value for command in VehicleCommand}
+
+        assert ours - set(self._rows()) == {
+            "CABIN_HVAC_THIRD_ROW_LEFT_SEAT_HEAT",
+            "CABIN_HVAC_THIRD_ROW_RIGHT_SEAT_HEAT",
+        }
+
+
+class TestTheMetricDoesNotDriftFromTheGateHelper:
+    """The depth-1 metric exists twice in this repo. Pin them together.
+
+    `scripts/gates/helpers/apk_vehicle_state_fields.py` owns the canonical
+    metric; `apk_corpus_sweep.py` replicates it rather than importing, because
+    the helper's public entry point takes a path to one of the nine pre-flight
+    classes while the sweep reads 26 whole trees. That is a defensible reason to
+    duplicate -- but a comment saying "the metric matches" cannot keep it true.
+    If the two drift, `APK_HISTORICAL_SWEEP.md`'s claim to use the helper's
+    metric becomes silently false, and the 15-to-2 collapse stops meaning what
+    it says.
+
+    These compare the two on synthetic input, so they exercise the shared string
+    logic without needing the gitignored classes and never skip.
+    """
+
+    BODY = (
+        "batteryLevel { timeStamp value } "
+        "gnssLocation { latitude longitude } "
+        "...VehicleStateFields "
+        "powerState { value }"
+    )
+    FRAGMENTS = {"VehicleStateFields": "driveMode { value } chargerState { value }"}
+
+    @staticmethod
+    def _helper():
+        path = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "scripts"
+            / "gates"
+            / "helpers"
+            / "apk_vehicle_state_fields.py"
+        )
+        spec = importlib.util.spec_from_file_location("apk_vehicle_state_fields", path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_top_level_splitting_agrees(self) -> None:
+        """Same depth-1 tokens, including the fragment spread."""
+        assert self._helper()._split_top_level(self.BODY) == sweep.split_top_level(
+            self.BODY
+        )
+
+    def test_selection_names_agree_including_resolved_fragments(self) -> None:
+        """Both resolve the spread; neither counts nested leaves."""
+        theirs = self._helper()._selection_names(self.BODY, self.FRAGMENTS)
+        ours = sweep.selection_names(self.BODY, self.FRAGMENTS)
+
+        assert theirs == ours
+        assert "latitude" not in ours
+        assert "driveMode" in ours


### PR DESCRIPTION
Builds a cross-version extractor over 54 decompiled versions of the Rivian
Android app (1.0.3 → 3.16.0), ships the ledger it produces, and corrects the
documentation claims the corpus falsified.

## The command side comes back negative, and that is the finding

The only cloud-sendable name the app carries that `VehicleCommand` lacks is
`INVALID_COMMAND`, a sentinel class. Fifty-four versions produced **no new
cloud-sendable command to probe**. Every other app-only command is BLE-only —
7 winch commands (1.0.3–1.4.1) and 3 pause commands — and this integration
sends via cloud after pairing, so none is reachable.

## Where the corpus earned its keep: refuting single-build claims

`REGENERATION.md` records fifteen subscribed `vehicleState` fields appearing in
zero of 3.15.0's 32,941 files. Holding this sweep's metric fixed and widening
only the corpus:

| measured against | residue |
|---|---|
| 3.15.0 alone | 15 |
| 26 versions | 2 |
| **54 versions** | **1 — `batteryCapacity`** |

Five of the seven `COMMANDS_ABSENT_FROM_THIS_APK` turn out to be commands 3.15.0
**dropped**, carrying both transports across 19–25 versions — not HA inventions.
Their "absent from APK 3.15.0" assertion is true and stays enforced; the
frozenset is untouched. The remaining two, `CABIN_HVAC_THIRD_ROW_{LEFT,RIGHT}_SEAT_HEAT`,
appear in no version at all, answering an open question in `const.py`.

**A rename, dated to a single build.** `CABIN_HOLD_ON`/`CABIN_HOLD_OFF` exist in
3.3.0 and nowhere else, becoming `CLIMATE_HOLD_ON`/`CLIMATE_HOLD_OFF` at 3.4.0.
A superseded spelling rather than a missing capability — invisible to any
sampling stride — and probably why we subscribe to `cabinHoldNotification`.

## Three fields probed live, all accepted

`scripts/probe_field_names.py` is read-only: subscriptions only, no command sent.
Each candidate rides alone with two known-good controls, because the server
rejects the whole document on one unknown name.

| field | result |
|---|---|
| `passiveEntryUnlockFailReason` | ACCEPTED, delivered `AT_HOME_DISABLE` |
| `vasAccessCanFaulted` | ACCEPTED, delivered `no_failure` |
| `vasSecureElementFaulted` | ACCEPTED, delivered `no_failure` |

Recorded with their limits: one sample from one R1T, `no_failure` is the healthy
arm of a fault enum whose other arms are unobserved, and `supportedFeatures`
gating still applies.

## Sensor surfaces (54 versions)

| surface | app | ours | app-only |
|---|---|---|---|
| `vehicleState` (depth-1) | 159 | 149 | 11 |
| Parallax RVM | 80 | 33 | **47** |
| `VehicleFeature` | 98 | 64 | 34 |
| charging / wallbox | 52 | 72 | 2 |

Parallax is the largest gap. It was recorded here as 3.x-only with 58 types;
`ParallaxAttributes` actually goes back to 2.19.1 and the corpus carries 80.

## Provenance

Three cohorts. A (`sources/`, 19 versions) and B (`java_src/`, 6) have an
**unrecorded** decompiler; C (`jadx/sources/`, 29 versions, 2.6.1–3.16.0) was
decompiled here with jadx 1.5.6 from APKMirror bundles. Counts compare only
within a cohort, because a count that moves across them cannot be attributed to
a real app change rather than a lossier extraction.

The Apollo document count is non-monotonic in both directions (0, 2, 3, 2, 3, 4,
3, 5). Two of my own errors are recorded in the doc rather than silently fixed:
a `.dex` binary counted as a source file, then an over-correction declaring the
corpus non-decreasing from a subsequence.

## Tests guard the shipped artifact, not just the extractor

One row shipped claiming 51 version-observations of a 26-version corpus before
that guard existed. `TestShippedLedgerIsGuarded` parses the shipped doc and
asserts no row can exceed the corpus size, and pins the enum-only residue. Tests
also pin the depth-1 metric against `scripts/gates/helpers/apk_vehicle_state_fields.py`,
which the sweep replicates rather than imports, so the two cannot drift apart.
`scripts/gates/s17.sh` exercises all three tree layouts and re-derives
independently of the extractor.

## Known limits

APKMirror carries nothing older than 2.5.1, and `3.2.x`, `2.9`, `2.11`–`2.18`
are absent from every source checked, so version windows in the ledger are
bounds, not birthdates. No decompiled proprietary source is committed — the
10 GB of trees stay gitignored under `.apk/`.

## Verification

2252 tests pass; `scripts/gates/s17.sh` exits 0; ruff and pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ghtvLMTtVYMqJfkxQZTjh