### PR TITLE
s37: 1.6.0-beta19

### DIFF
--- a/custom_components/rivian/const.py
+++ b/custom_components/rivian/const.py
@@ -27,7 +27,7 @@ from .data_classes import (
 
 NAME = "Rivian (Unofficial)"
 DOMAIN = "rivian"
-VERSION = "1.6.0-beta18"
+VERSION = "1.6.0-beta19"
 ISSUE_URL = "https://github.com/bretterer/home-assistant-rivian/issues"
 
 # Attributes

--- a/custom_components/rivian/manifest.json
+++ b/custom_components/rivian/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "bleak>=0.21"
   ],
-  "version": "1.6.0-beta18"
+  "version": "1.6.0-beta19"
 }


### PR DESCRIPTION
Version bump only — `manifest.json` and `const.py`, per the repo's release rule.

## Hardware-verified first

This release carries a live-behaviour change no test can cover: `RVM_DECODERS` went 33 → 37 in s34, and `SUBSCRIBED_RVMS` derives from it (`coordinator.py:453`), so a vehicle running this build opens four subscriptions it did not before. `beta13` passed 1845 tests and the gateway probe, then crashed on every frame on real hardware.

Deployed `cd544fc` to the live host, rollback kept at `/homeassistant/rivian-rollback-beta17`:

| check | result |
|---|---|
| HA 2026.8.3 back up, integration loaded | ✅ |
| Rivian ERROR/WARNING since restart | **0** (only HA's routine "custom integration not tested" notice) |
| Parallax subscription delivers **and decodes** under 37 topics | ✅ gear-change and closures automations fired at 09:30 on live data — both RVM-decoded topics |
| The four s34 topics publish | ✅ 5/5 captured, with HA subscribed |

The one traceback in the log buffer is a DNS timeout dated **2026-08-28**, five days before the deploy — `ha core logs` reaches back that far.

The only `custom_components/` delta between the verified tree and this one is the version string.

## Notes

The host was on `beta17`, not the `beta14` the workspace notes claimed.

## Verification

`2425 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ghtvLMTtVYMqJfkxQZTjh