### PR TITLE
s39: drop the s30 MITM capture branch, and keep what it measured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,8 +199,3 @@ docs/development/apk/*.java
 
 # gh-sweep: salt for community fixture vehicle-fingerprint digests (never commit)
 tests/fixtures/community/.salt
-
-# APK MITM capture artifacts — may contain session tokens even with redaction.
-# Patched-APK output and frida-server binaries need no rule: `.apk/` above
-# already covers them.
-captures/apk_mitm/


### PR DESCRIPTION
Deletes `s30-apk-mitm-capture` per the owner's decision, and removes the orphaned `captures/apk_mitm/` ignore rule that s27 shipped without its tool.

The commit message carries what the branch measured, because the code goes and the measurements are worth more than the tooling:

1. **The app's primary GraphQL front door is not ours** — 68 of 198 flows on `rivian.com/api/gql/gateway/graphql` vs 24 on the `api.rivian.com` host `rivian_client` uses. A document seen in an app capture is not thereby reachable on our endpoint.
2. **`supported_features_observed.json` is corroborated across two transports** — the 2026-08-26 capture's SupportedFeatures response was content-identical, same 55 names, empty set difference both ways. This is load-bearing for the honk-and-flash finding in #16.
3. **Why it never left local** — its own gate was a live re-run against the real gateway, needing an emulator and a Rivian login. Never met.

`72b4903` is recorded as a **tombstone, not a recovery path**: after `branch -D` and `worktree remove` the object is unreachable and gc prunes it.

Branch and worktree deletion happens only after this merges.

## Verification
- `.gitignore` only; no code paths touched.
- No `captures/` directory exists in the checkout or the worktree, so the rule guarded nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ghtvLMTtVYMqJfkxQZTjh