### PR TITLE
s41b: deslop pass on the ralph session's changed files

### DIFF
--- a/tests/test_s40_entities.py
+++ b/tests/test_s40_entities.py
@@ -401,14 +401,11 @@ class TestGatingMeasuredOnOtherVehicles:
             for flag in self._features(name) & self.S40_GATES
         }
         assert advertised == {"ENRG_MONTR_PARK", "V_GGVS"}
-        assert "AUTO_VENT" not in advertised
 
         # Our own truck DOES advertise it, so it is not advertised by nobody --
         # which is the difference between this and TONNEAU_CMD.
         observed = json.loads(
-            (pathlib.Path(__file__).parent / "fixtures")
-            .joinpath("supported_features_observed.json")
-            .read_text()
+            (self.COMMUNITY.parent / "supported_features_observed.json").read_text()
         )
         ours = set(observed["vehicles"][0]["features"])
         assert "AUTO_VENT" in ours


### PR DESCRIPTION
Ralph's mandatory post-review cleanup (Step 7.5), scoped to this session's 19 changed files. **Deletion-only** — no behaviour change, no new abstraction.

- Dropped `assert "AUTO_VENT" not in advertised` — strictly implied by the set-equality assertion above it
- The our-truck fixture read re-derived its path from `__file__` when the class already holds `COMMUNITY`

## Deliberately not consolidated

The eleven s40 field names appear as literals in four files (`parallax.py` emits them, `const.py` registers them, `test_parallax_gap_fill.py` mirrors them, `test_s40_entities.py` pins them). That reads as duplication and is the repo's **drift-guard design** — the mirror exists so a change in one place fails an equality assert instead of passing silently. Collapsing it would remove the guard, not the slop.

Same for the long explanatory comments: they are house convention and record *why*, which several of this session's corrections depend on.

## Verification
`pytest` 2495 passed (unchanged), `ruff` clean, `f11` 30/0, `dump_entity_sets --check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ghtvLMTtVYMqJfkxQZTjh